### PR TITLE
upgrade scrypt, node package for node 0.12.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "compression": "1.0.9",
     "q": "0.9.x",
     "google-spreadsheet": "0.2.7",
-    "scrypt": "~1.7.4",
+    "scrypt": "4.0.7",
     "passport": "",
     "passport-google-oauth": "",
     "i18n-abide": "~0.0.22",
@@ -41,7 +41,7 @@
     "supertest": ""
   },
   "engines": {
-    "node": "0.10.17",
+    "node": ">=0.10.17",
     "npm": ""
   },
   "scripts": {


### PR DESCRIPTION

Installation of opendatacensus from master fails on node installations of 0.12.x 
I've confirmed this twice, on my computer locally, [and on a friend's](https://gist.github.com/skorasaurus/f7a9dad7103ec1d4d306) (gist of install error). 

The scrypt package (node-scrypt), at 1.7.4 in our master, [doesn't support node >=0.11](https://github.com/barrysteyn/node-scrypt/issues/39).  Support for node 0.12 was added in https://github.com/barrysteyn/node-scrypt/commit/223f039f410d3f80903ad7f0b0bf71e7956fb8a4 

I did a new install of opendatacensus with my updated package.json and was able to locally run it without noticeable problems. There were [a couple notices in the terminal](https://gist.github.com/f0ad2f58e70e43f10324) while running it. 

Here's the results from my [mocha test](https://gist.github.com/2eb4c4d817088bf301c5) 
and the [install log from npm]https://gist.github.com/b985622d1d3c878576f3 