### PR TITLE
Fix line wrapping of tooltips.

### DIFF
--- a/census/public/css/style.css
+++ b/census/public/css/style.css
@@ -109,6 +109,7 @@ a i[class*='icon-'] {
 
 .tooltip-inner {
 	max-width: 350px;
+	white-space: normal;
 }
 
 a.icon-hover {


### PR DESCRIPTION
This should address part of #618. On place overview pages, when I hover over one of the logos in the breakdown columns, the text in the tooltip doesn't wrap correctly so you can only read the first few words. But this bug only applies to rows that have data due to [this](https://github.com/okfn/opendatacensus/blob/develop/census/public/css/style.css#L94) line of code. Anyway, hopefully this is a reasonable way to fix it.