### PR TITLE
In the overview, 'Add' buttons should be at the bottom of cells.

### DIFF
--- a/census/public/css/style.css
+++ b/census/public/css/style.css
@@ -763,9 +763,13 @@ table.response-summary td {
 	padding: 0;
 }
 
-.response-summary tbody td {
+table.response-summary tbody td {
   vertical-align: middle;
   text-align: center;
+}
+
+table.response-summary tbody td.showpopover {
+  vertical-align: bottom;
 }
 
 table.response-summary td.placescore span {


### PR DESCRIPTION
Not sure if this is still relevant after recent changes, but the "Add" buttons were in the middle of cells which looked awkward.