### PR TITLE
Log stack trace for 500-level errors

### DIFF
--- a/census/middlewares/index.js
+++ b/census/middlewares/index.js
@@ -13,7 +13,7 @@ var notFound = function(req, res, next) {
 
 
 var internalServerError = function(err, req, res, next) {
-
+  console.error(err.stack);
   res.status(500)
     .render('500.html', {
       title:'500: Internal Server Error',


### PR DESCRIPTION
This makes debugging these errors not impossible.