### PR TITLE
FIX facebook login/auth

### DIFF
--- a/census/routes/utils.js
+++ b/census/routes/utils.js
@@ -87,7 +87,8 @@ var setupAuth = function () {
       .replace('SCHEME', config.get('connection_scheme'))
       .replace('SUB', config.get('auth_subdomain'))
       .replace('DOMAIN', config.get('base_domain'))
-      .replace('PATH', 'facebook/callback')
+      .replace('PATH', 'facebook/callback'),
+    profileFields: ['id', 'name', 'email', 'photos']
   }, function (accessToken, refreshToken, profile, done) {
 
     resolveProfile(profile, 'facebook', done);


### PR DESCRIPTION
Without specifying the profile fields we want, all we get back from FB is id and name, which leads to a 500 because the serializer expects email, etc.