### PR TITLE
Move 'show more' button just below hidden text

### DIFF
--- a/census/public/css/style.css
+++ b/census/public/css/style.css
@@ -1216,7 +1216,7 @@ td.dependant {width:924px !important;}/*Setting the width of column 3.*/
 .submission-info, .submission-dependant {
     float: left;
     min-height: 72px;
-    padding-top: 2em;
+    padding-bottom: 2em;
 }
 
 .head .submission-question, .head .submission-option, .head .submission-current,
@@ -1414,7 +1414,6 @@ table.faq-table tr td:first-child {
 
 a.readmore-js-toggle {
     text-decoration: none;
-
 }
 
 a.readmore-js-toggle:hover {
@@ -1422,9 +1421,7 @@ a.readmore-js-toggle:hover {
 }
 
 .readmore-js-toggle {
-    position: absolute;
-    top: 0;
-    right: 0;
+    float: right;
     background-color: grey;
     color: white;
     height: 1.5em;


### PR DESCRIPTION
Having the button at the bottom makes it more obviously clickable since it's right below what you're reading. You've reached this far with your eyes, now you want to read more, and the button is just there.

When it's above the text, I always land up clicking the button for the item *below*, because that's nearest to where my eye is when I reach the part of the text that is hidden.