### PR TITLE
Don't use class="row" on overview page

### DIFF
--- a/census/views/overview.html
+++ b/census/views/overview.html
@@ -26,7 +26,7 @@
 </div>
 {% endif %}
 
-<div class="row">
+<div>
   <div class="pull-left">{% include '_snippets/key.html' %}</div>
 
   <div class="pull-right">
@@ -36,7 +36,7 @@
   </div>
 </div>
 
-<div class="row">
+<div>
   {% include '_snippets/year_navigation.html' %}
     <div class="span6" id="sorting">
     </div>


### PR DESCRIPTION
This offsets the key at the top of overview page in a weird way, pushing it out of the visual column of the rest of the page. The class doesn't seem to do anything else.