### PR TITLE
Disable sticky header in IE

### DIFF
--- a/census/public/src/census.js
+++ b/census/public/src/census.js
@@ -82,8 +82,10 @@ $(document).ready(function($) {
     $('a[data-toggle="popover"]').popover();
 
   };
-    
-  sexyTables();
+
+  if ( !$.browser.msie ) {
+    sexyTables();
+  }
 
   var summary,
       $table = $('.response-summary');


### PR DESCRIPTION
To prevent display error mentioned in #668, avoid calling sexyTables in msie.