### PR TITLE
Add docker-compose

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -1,0 +1,21 @@
+# Application Settings
+DEBUG=false
+PORT=5000
+REGISTRY_URL=https://docs.google.com/spreadsheets/d/18jINMw7ifwUoqizc4xaQE8XtF4apPfsmMN43EM-9Pmc/edit#gid=0
+AUTH_SUBDOMAIN=id
+SYSTEM_SUBDOMAIN=system
+DISCUSSION_FORUM=https://discuss.okfn.org/c/open-data-index
+
+# Database Settings
+DB_USER=postgres
+DB_HOST=db
+DB_NAME=postgres
+DB_PORT=5432
+
+# Google API Credentials
+GOOGLE_APP_ID=
+GOOGLE_APP_SECRET=
+
+# Facebook API Credentials
+FACEBOOK_APP_ID=
+FACEBOOK_APP_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:4.2
+
+RUN apt-get install -y git curl python
+RUN apt-get install -y make automake gcc g++ cpp openssl libc6-dev autoconf pkg-config
+RUN mkdir -p /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Open Data Census is a Node.js app, running Express v4 and Postgres 9.4 for the d
 
 Get a local server setup with the following steps:
 
+#### Using Docker
+
+1. Install [Docker Compose](https://docs.docker.com/compose/install/) for your OS.
+2. Clone this repository.
+3. Add your Facebook and Google API tokens in the provided [.docker.env](./.docker.env) file. Additionally, you may create a `settings.json` file as detailed in the [Manual Setup section](#manual-setup).
+4. From the root directory of the cloned repository, run `docker-compose up`.
+
+#### Manual Setup
+
 **NOTE**: If you need to prefix your commands in your local environment with `sudo`, then do that.
 
 1. Install Postgres 9.4 on your machine.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+web:
+    build: .
+    env_file: .docker.env
+    ports:
+        - "5000:5000"
+    links:
+        - db
+    volumes:
+        - .:/usr/src/app
+
+db:
+    image: postgres:9.4

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "serve-favicon": "^2.2.1",
     "subdomain": "^1.2.0",
     "supertest-as-promised": "^2.0.2",
-    "throng": "^1.0.0",
+    "throng": "^1.0.1",
     "umzug": "^1.6.0",
     "underscore": "^1.8.3",
     "validator": "^3.41.2"
@@ -72,7 +72,7 @@
     "zombie": "^4.1.0"
   },
   "engines": {
-    "node": "4.1.x",
+    "node": "4.2.x",
     "npm": "2.14.x"
   },
   "scripts": {


### PR DESCRIPTION
This adds docker-compose for development use (#727).

I would like to help out more with this project, but even with using Docker, setting up a proper development environment for this project is still too complex and cryptic for outside collaborators. Because there is no existing Docker image for node 4.1.x, I changed the required Node version to 4.2.x.

Hopefully this PR can be useful to you, even though it's not 100% complete. Cheers.