### PR TITLE
Validate place and dataset ids for submitted entry data

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,3 +21,7 @@ rules:
     - off
   guard-for-in:
     - off
+  no-negated-condition:
+    - warn
+  no-else-return:
+    - warn

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@ rules:
     - avoid-escape
   semi:
     - error
-    - never
+    - always
   space-before-function-paren:
     - off
   guard-for-in:

--- a/census/app.js
+++ b/census/app.js
@@ -127,7 +127,7 @@ function start() {
   return new Promise(function(resolve, reject) {
     app.get('models').umzug.up().then(function() {
       var server = app.listen(app.get('port'), function() {
-        // console.log('Listening on ' + app.get('port'));
+        console.log('Listening on ' + app.get('port'));
         resolve({
           app: app,
           server: server

--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -28,7 +28,6 @@ var submitGetHandler = function(req, res, data) {
 };
 
 var submitPostHandler = function(req, res, data) {
-  var errors;
   var objToSave = {};
   var answers;
   var saveStrategy;
@@ -44,133 +43,133 @@ var submitPostHandler = function(req, res, data) {
     approveFirstSubmission = req.params.site.settings[settingName];
   }
 
-  errors = utils.validateData(req);
-
-  if (pending) {
-    if (!Array.isArray(errors)) {
-      errors = [];
-    }
-    errors.push({
-      param: 'conflict',
-      msg: 'There is already a queued submission for this data. ' +
-        '<a href="/place/PL/YR">See the queued submission</a>'
-        .replace('PL', current.place).replace('YR', current.year)
-    });
-  }
-
-  if (errors) {
-    var addDetails = _.find(data.questions, function(q) {
-      return q.id === 'details';
-    });
-
-    res.statusCode = 400;
-    var settingName = 'submit_page';
-    res.render('create.html', {
-      canReview: true, // flag always on for submission
-      submitInstructions: req.params.site.settings[settingName],
-      places: modelUtils.translateSet(req, data.places),
-      datasets: modelUtils.translateSet(req, data.datasets),
-      questions: data.questions,
-      addDetails: addDetails,
-      year: req.app.get('year'),
-      current: current,
-      errors: errors,
-      formData: req.body
-    });
-  } else {
-    if (req.body.anonymous && req.body.anonymous === 'false') {
-      anonymous = false;
-      submitterId = req.user.id;
+  utils.validateData(req).then(function(errors) {
+    if (pending) {
+      if (!Array.isArray(errors)) {
+        errors = [];
+      }
+      errors.push({
+        param: 'conflict',
+        msg: 'There is already a queued submission for this data. ' +
+          '<a href="/place/PL/YR">See the queued submission</a>'
+          .replace('PL', current.place).replace('YR', current.year)
+      });
     }
 
-    if (!current || current.year !== req.app.get('year')) {
-      console.log('we are definitely creating a new entry');
+    if (errors) {
+      var addDetails = _.find(data.questions, function(q) {
+        return q.id === 'details';
+      });
 
-      objToSave.id = uuid.v4();
-      objToSave.site = req.params.site.id;
-      objToSave.place = req.body.place;
-      objToSave.dataset = req.body.dataset;
-      objToSave.details = req.body.details;
-      objToSave.year = req.app.get('year');
-      objToSave.submitterId = submitterId;
-
-      if (approveFirstSubmission) {
-        objToSave.isCurrent = true;
-        objToSave.reviewed = true;
-        objToSave.reviewResult = true;
-        objToSave.reviewerId = submitterId;
-      } else {
-        objToSave.isCurrent = false;
+      res.statusCode = 400;
+      var settingName = 'submit_page';
+      res.render('create.html', {
+        canReview: true, // flag always on for submission
+        submitInstructions: req.params.site.settings[settingName],
+        places: modelUtils.translateSet(req, data.places),
+        datasets: modelUtils.translateSet(req, data.datasets),
+        questions: data.questions,
+        addDetails: addDetails,
+        year: req.app.get('year'),
+        current: current,
+        errors: errors,
+        formData: req.body
+      });
+    } else {
+      if (req.body.anonymous && req.body.anonymous === 'false') {
+        anonymous = false;
+        submitterId = req.user.id;
       }
 
-      saveStrategy = 'create';
-    } else if (current.isCurrent) {
-      console.log('we have existing current entry, so create a new submission');
+      if (!current || current.year !== req.app.get('year')) {
+        console.log('we are definitely creating a new entry');
 
-      objToSave.id = uuid.v4();
-      objToSave.site = req.params.site.id;
-      objToSave.place = req.body.place;
-      objToSave.dataset = req.body.dataset;
-      objToSave.submissionNotes = req.body.details;
-      objToSave.details = req.body.details;
-      objToSave.year = req.app.get('year');
-      objToSave.isCurrent = false;
-      objToSave.submitterId = submitterId;
+        objToSave.id = uuid.v4();
+        objToSave.site = req.params.site.id;
+        objToSave.place = req.body.place;
+        objToSave.dataset = req.body.dataset;
+        objToSave.details = req.body.details;
+        objToSave.year = req.app.get('year');
+        objToSave.submitterId = submitterId;
 
-      saveStrategy = 'create';
-    } else {
-      console.log('we have existing submission and no current entry. we ' +
-        'usually should not get here because of earlier condition that ' +
-        'lodges a conflict error on the form');
-
-      objToSave = current;
-
-      saveStrategy = 'update';
-    }
-
-    answers = req.body;
-    delete answers.place;
-    delete answers.dataset;
-    delete answers.year;
-    delete answers.details;
-    delete answers.anonymous;
-    objToSave.answers = utils.normalizedAnswers(answers);
-
-    if (saveStrategy === 'create') {
-      query = req.app.get('models').Entry.create(objToSave);
-    } else if (saveStrategy === 'update') {
-      query = objToSave.save();
-    }
-
-    query.then(function(result) {
-      var msg;
-      var msgTmpl;
-      var redirectPath;
-      var submissionPath;
-
-      if (!result) {
-        msg = 'There was an error!';
-        req.flash('error', msg);
-      } else {
-        msgTmpl = 'Thanks for your submission.REVIEWED You can check ' +
-          'back here any time to see the current status.';
-
-        if (!result.isCurrent) {
-          msg = msgTmpl.replace('REVIEWED',
-            ' It will now be reviewed by the editors.');
-          submissionPath = '/submission/' + result.id;
-          redirectPath = submissionPath;
+        if (approveFirstSubmission) {
+          objToSave.isCurrent = true;
+          objToSave.reviewed = true;
+          objToSave.reviewResult = true;
+          objToSave.reviewerId = submitterId;
         } else {
-          msg = msgTmpl.replace('REVIEWED', '');
-          submissionPath = '/submission/' + result.id;
-          redirectPath = '/place/' + result.place;
+          objToSave.isCurrent = false;
         }
 
-        req.flash('info', msg);
+        saveStrategy = 'create';
+      } else if (current.isCurrent) {
+        console.log('we have existing current entry, so create a new submission');
+
+        objToSave.id = uuid.v4();
+        objToSave.site = req.params.site.id;
+        objToSave.place = req.body.place;
+        objToSave.dataset = req.body.dataset;
+        objToSave.submissionNotes = req.body.details;
+        objToSave.details = req.body.details;
+        objToSave.year = req.app.get('year');
+        objToSave.isCurrent = false;
+        objToSave.submitterId = submitterId;
+
+        saveStrategy = 'create';
+      } else {
+        console.log('we have existing submission and no current entry. we ' +
+          'usually should not get here because of earlier condition that ' +
+          'lodges a conflict error on the form');
+
+        objToSave = current;
+
+        saveStrategy = 'update';
       }
-      res.redirect(redirectPath + '?post_submission=' + submissionPath);
-    }).catch(console.trace.bind(console));
-  }
+
+      answers = req.body;
+      delete answers.place;
+      delete answers.dataset;
+      delete answers.year;
+      delete answers.details;
+      delete answers.anonymous;
+      objToSave.answers = utils.normalizedAnswers(answers);
+
+      if (saveStrategy === 'create') {
+        query = req.app.get('models').Entry.create(objToSave);
+      } else if (saveStrategy === 'update') {
+        query = objToSave.save();
+      }
+
+      query.then(function(result) {
+        var msg;
+        var msgTmpl;
+        var redirectPath;
+        var submissionPath;
+
+        if (!result) {
+          msg = 'There was an error!';
+          req.flash('error', msg);
+        } else {
+          msgTmpl = 'Thanks for your submission.REVIEWED You can check ' +
+            'back here any time to see the current status.';
+
+          if (!result.isCurrent) {
+            msg = msgTmpl.replace('REVIEWED',
+              ' It will now be reviewed by the editors.');
+            submissionPath = '/submission/' + result.id;
+            redirectPath = submissionPath;
+          } else {
+            msg = msgTmpl.replace('REVIEWED', '');
+            submissionPath = '/submission/' + result.id;
+            redirectPath = '/place/' + result.place;
+          }
+
+          req.flash('info', msg);
+        }
+        res.redirect(redirectPath + '?post_submission=' + submissionPath);
+      }).catch(console.trace.bind(console));
+    }
+  });
 };
 
 var pendingEntry = function(req, res) {

--- a/census/controllers/utils.js
+++ b/census/controllers/utils.js
@@ -104,27 +104,25 @@ var validateQuestion = function(req, question, parentQuestion, validated) {
   // ensure false values for expectFalse questions
   if (value === 'false' && validator.expectFalse) {
     validator.expectFalse.forEach(function(child) {
-      if (validated.indexOf(child) == -1) {
+      if (validated.indexOf(child) === -1) {
         req.checkBody(child, 'You can specify only \'false\'').equals('false');
         validated.push(child);
       }
     });
   }
 
-  if (validated.indexOf(question) == -1) {
+  if (validated.indexOf(question) === -1) {
     // not yet validated
     // validate depending on the question value
     if (parentValue === 'null' || parentValue === 'false') {
       // validate falsy values
       if (validator.type === 'string') {
         req.checkBody(question, 'You must not specify this field').equals('');
-      } else {
-        if (!(
-          (parentValue === 'null') && (validators[parentQuestion].expectFalse))
-        ) {
-          req.checkBody(question, 'You can specify only \'' +
-            parentValue + '\'').equals(parentValue);
-        }
+      } else if (!(
+        (parentValue === 'null') && (validators[parentQuestion].expectFalse))
+      ) {
+        req.checkBody(question, 'You can specify only \'' +
+          parentValue + '\'').equals(parentValue);
       }
     } else {
       // parentValue has a truthy value, validate as normal
@@ -251,7 +249,6 @@ var getFormQuestions = function(req, questions) {
         });
       });
     }
-
   });
   return _.sortByOrder(questions, 'order', 'asc');
 };

--- a/debug-server.js
+++ b/debug-server.js
@@ -1,4 +1,6 @@
 'use strict';
 
-var start = require('./census/app').start;
-start().then((result) => { console.log('SERVER STARTED'); });
+const start = require('./census/app').start;
+start().then(result => {
+  console.log('SERVER STARTED');
+});

--- a/debug-server.js
+++ b/debug-server.js
@@ -1,0 +1,4 @@
+'use strict';
+
+var start = require('./census/app').start;
+start().then((result) => { console.log('SERVER STARTED'); });

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "migrate_entries": "node scripts/entries.js",
     "migrate_users": "node scripts/users.js",
     "start": "node server.js",
-    "debug": "node-debug server.js",
+    "debug": "node-debug debug-server.js",
     "test": "NODE_ENV=test ./node_modules/istanbul/lib/cli.js cover -x '**/census/migrations/**' -x '**/scripts/**' ./node_modules/mocha/bin/_mocha -- -R spec tests/ --harmony",
     "jscs": "jscs census/*.js census/**/*.js fixtures scripts tests"
   }

--- a/server.js
+++ b/server.js
@@ -4,7 +4,6 @@ var throng = require('throng');
 var start = require('./census/app').start;
 var WORKERS = process.env.WEB_CONCURRENCY || 1;
 
-
 throng(start, {
   workers: WORKERS,
   lifetime: Infinity

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var throng = require('throng');
-var start = require('./census/app').start;
-var WORKERS = process.env.WEB_CONCURRENCY || 1;
+const throng = require('throng');
+const start = require('./census/app').start;
+const WORKERS = process.env.WEB_CONCURRENCY || 1;
 
 throng(start, {
   workers: WORKERS,

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -1,249 +1,249 @@
-'use strict'
+'use strict';
 
-const assert = require('chai').assert
-const censusConfig = require('../census/config')
-const siteID = 'site1'
+const assert = require('chai').assert;
+const censusConfig = require('../census/config');
+const siteID = 'site1';
 const REGISTRY_URL = 'https://docs.google.com/spreadsheets/d/1FK5dzeNeJl81oB76n' +
-  'WzhS1dAdnXDoZbbe_vTH4NlThM/edit#gid=0'
-const testUtils = require('./utils')
-const userFixtures = require('../fixtures/user')
-const Promise = require('bluebird')
+  'WzhS1dAdnXDoZbbe_vTH4NlThM/edit#gid=0';
+const testUtils = require('./utils');
+const userFixtures = require('../fixtures/user');
+const Promise = require('bluebird');
 
 describe('Admin page', function () {
-  this.timeout(20000)
+  this.timeout(20000);
 
-  before(testUtils.startApplication)
-  after(testUtils.shutdownApplication)
+  before(testUtils.startApplication);
+  after(testUtils.shutdownApplication);
 
   const configValues = {
     registryUrl: censusConfig.get('registryUrl')
-  }
+  };
 
   after(function () {
     for (var setting in configValues) {
-      censusConfig.set(setting, configValues[setting])
+      censusConfig.set(setting, configValues[setting]);
     }
-  })
+  });
 
   before(function () {
-    let config = testUtils.app.get('config')
-    config.set('test:testing', true)
+    let config = testUtils.app.get('config');
+    config.set('test:testing', true);
     config.set('test:user', {
       userid: userFixtures[0].data.id,
       emails: userFixtures[0].data.emails
-    })
-    config.set('registryUrl', REGISTRY_URL)
-    this.browser = testUtils.browser
-    this.app = testUtils.app
-  })
+    });
+    config.set('registryUrl', REGISTRY_URL);
+    this.browser = testUtils.browser;
+    this.app = testUtils.app;
+  });
 
   beforeEach(function () {
-    return this.browser.visit('/admin')
-  })
+    return this.browser.visit('/admin');
+  });
 
   it('should load admin page successfully', function () {
-    this.browser.assert.success()
-    this.browser.assert.text('title', 'Dashboard -')
-  })
+    this.browser.assert.success();
+    this.browser.assert.text('title', 'Dashboard -');
+  });
 
   describe('reload config button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Reload Config')
-    })
+      return this.browser.pressButton('Reload Config');
+    });
 
     it('should load config', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
       return this.app.get('models').Site.findById(siteID).then(function (data) {
-        assert.isNotNull(data)
-        assert.notEqual(data.places, '')
-        assert.notEqual(data.places, '')
-        assert.notEqual(data.datasets, '')
-        assert.notEqual(data.questions, '')
-      })
-    })
-  })
+        assert.isNotNull(data);
+        assert.notEqual(data.places, '');
+        assert.notEqual(data.places, '');
+        assert.notEqual(data.datasets, '');
+        assert.notEqual(data.questions, '');
+      });
+    });
+  });
 
   describe('reload places button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Reload Places')
-    })
+      return this.browser.pressButton('Reload Places');
+    });
 
     it('should load places', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
       return this.app.get('models').Place.findAll({where: {site: siteID}})
         .then(function (data) {
-          assert.equal(data.length, 3)
-        })
-    })
-  })
+          assert.equal(data.length, 3);
+        });
+    });
+  });
 
   describe('reload datasets button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Reload Datasets')
-    })
+      return this.browser.pressButton('Reload Datasets');
+    });
 
     it('should load datasets', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
       return this.app.get('models').Dataset.findAll({where: {site: siteID}})
         .then(function (data) {
-          assert.equal(data.length, 15)
-        })
-    })
-  })
+          assert.equal(data.length, 15);
+        });
+    });
+  });
 
   describe('reload questions button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Reload Questions')
-    })
+      return this.browser.pressButton('Reload Questions');
+    });
 
     it('should load questions', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
       return this.app.get('models').Question.findAll({where: {site: siteID}})
         .then(function (data) {
-          assert.equal(data.length, 18)
-        })
-    })
-  })
-})
+          assert.equal(data.length, 18);
+        });
+    });
+  });
+});
 
 describe('System Control page', function () {
-  this.timeout(20000)
+  this.timeout(20000);
 
-  before(testUtils.startApplication)
-  after(testUtils.shutdownApplication)
+  before(testUtils.startApplication);
+  after(testUtils.shutdownApplication);
 
   const configValues = {
     registryUrl: censusConfig.get('registryUrl')
-  }
-  let appSysAdmin = ''
+  };
+  let appSysAdmin = '';
 
   before(function () {
-    let config = testUtils.app.get('config')
-    config.set('test:testing', true)
+    let config = testUtils.app.get('config');
+    config.set('test:testing', true);
     config.set('test:user', {
       userid: userFixtures[0].data.id,
       emails: userFixtures[0].data.emails
-    })
-    config.set('registryUrl', REGISTRY_URL)
-    this.browser = testUtils.browser
-    let port = testUtils.app.get('port')
-    this.browser.site = 'http://system.dev.census.org:' + port + '/'
-    this.app = testUtils.app
+    });
+    config.set('registryUrl', REGISTRY_URL);
+    this.browser = testUtils.browser;
+    let port = testUtils.app.get('port');
+    this.browser.site = 'http://system.dev.census.org:' + port + '/';
+    this.app = testUtils.app;
     // temporarily change sysAdmin (reset in `after`)
-    appSysAdmin = this.app.get('sysAdmin')
-    this.app.set('sysAdmin', userFixtures[0].data.emails)
-  })
+    appSysAdmin = this.app.get('sysAdmin');
+    this.app.set('sysAdmin', userFixtures[0].data.emails);
+  });
 
   after(function () {
     for (var setting in configValues) {
-      censusConfig.set(setting, configValues[setting])
+      censusConfig.set(setting, configValues[setting]);
     }
-    this.app.set('sysAdmin', appSysAdmin)
-  })
+    this.app.set('sysAdmin', appSysAdmin);
+  });
 
   beforeEach(function () {
-    return this.browser.visit('/control')
-  })
+    return this.browser.visit('/control');
+  });
 
   it('should load admin page successfully', function () {
-    this.browser.assert.success()
-    this.browser.assert.text('title', 'Dashboard -')
-  })
+    this.browser.assert.success();
+    this.browser.assert.text('title', 'Dashboard -');
+  });
 
   describe('Load Configs button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Load Configs')
-    })
+      return this.browser.pressButton('Load Configs');
+    });
 
     it('should load configs', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
 
       return Promise.join(
         this.app.get('models').Site.count(),
         this.app.get('models').Site.findById(siteID),
         function(count, siteData) {
-          assert.equal(count, 2)
-          assert.isNotNull(siteData)
-          assert.notEqual(siteData.places, '')
-          assert.notEqual(siteData.places, '')
-          assert.notEqual(siteData.datasets, '')
-          assert.notEqual(siteData.questions, '')
+          assert.equal(count, 2);
+          assert.isNotNull(siteData);
+          assert.notEqual(siteData.places, '');
+          assert.notEqual(siteData.places, '');
+          assert.notEqual(siteData.datasets, '');
+          assert.notEqual(siteData.questions, '');
         }
-      )
-    })
-  })
+      );
+    });
+  });
 
   describe('Load Places button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Load Places')
-    })
+      return this.browser.pressButton('Load Places');
+    });
 
     it('should load places', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
       return this.app.get('models').Place.findAll({where: {site: siteID}})
         .then(function (data) {
-          assert.equal(data.length, 3)
-        })
-    })
-  })
+          assert.equal(data.length, 3);
+        });
+    });
+  });
 
   describe('Load Datasets button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Load Datasets')
-    })
+      return this.browser.pressButton('Load Datasets');
+    });
 
     it('should load datasets', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
       return this.app.get('models').Dataset.findAll({where: {site: siteID}})
         .then(function (data) {
-          assert.equal(data.length, 15)
-        })
-    })
-  })
+          assert.equal(data.length, 15);
+        });
+    });
+  });
 
   describe('Load Questions button action', function () {
     beforeEach(function () {
-      return this.browser.pressButton('Load Questions')
-    })
+      return this.browser.pressButton('Load Questions');
+    });
 
     it('should load questions', function () {
-      this.browser.assert.success()
-      let html = this.browser.resources[0].response.body
-      let jsonData = JSON.parse(html)
-      assert.equal(jsonData.status, 'ok')
-      assert.equal(jsonData.message, 'ok')
+      this.browser.assert.success();
+      let html = this.browser.resources[0].response.body;
+      let jsonData = JSON.parse(html);
+      assert.equal(jsonData.status, 'ok');
+      assert.equal(jsonData.message, 'ok');
       return this.app.get('models').Question.findAll({where: {site: siteID}})
         .then(function (data) {
-          assert.equal(data.length, 18)
-        })
-    })
-  })
-})
+          assert.equal(data.length, 18);
+        });
+    });
+  });
+});

--- a/tests/submissions.js
+++ b/tests/submissions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash');
 var express = require('express');
 var bodyParser = require('body-parser');
@@ -13,7 +15,6 @@ function validation(req, res) {
 }
 
 var validationApp = function(validation) {
-
   var port = 8901;
   var app = express();
 
@@ -96,16 +97,16 @@ describe('#validationData()', function() {
 
   describe('Survey flow', function() {
     it('should return errors for online, machinereadable and ' +
-      'bulk (digital=false)', function(done) {
-        postRoute(_.assign(sumbission, {
-          digital: 'false'
-        }), done, function(errors) {
-          expect(errors).to.have.property('online');
-          expect(errors).to.have.property('machinereadable');
-          expect(errors).to.have.property('bulk');
-          expect(_.size(errors)).to.be.equal(3);
-        });
+        'bulk (digital=false)', function(done) {
+      postRoute(_.assign(sumbission, {
+        digital: 'false'
+      }), done, function(errors) {
+        expect(errors).to.have.property('online');
+        expect(errors).to.have.property('machinereadable');
+        expect(errors).to.have.property('bulk');
+        expect(_.size(errors)).to.be.equal(3);
       });
+    });
     it('should return errors for free, openlicense (public=false)',
       function(done) {
         postRoute(_.assign(sumbission, {
@@ -161,47 +162,47 @@ describe('#validationData()', function() {
 
     it('should return no error (public=true => openlicense=false; ' +
       'licenseurl = "")', function(done) {
-        postRoute(_.assign(sumbission, {
-          public: 'true',
-          openlicense: 'false',
-          licenseurl: ''
-        }), done, function(errors) {
-          expect(_.size(errors)).to.be.equal(0);
-        });
+      postRoute(_.assign(sumbission, {
+        public: 'true',
+        openlicense: 'false',
+        licenseurl: ''
+      }), done, function(errors) {
+        expect(_.size(errors)).to.be.equal(0);
       });
+    });
 
     it('should return no error (public=true => openlicense=null; ' +
       'licenseurl: "")', function(done) {
-        postRoute(_.assign(sumbission, {
-          public: 'true',
-          openlicense: 'null',
-          licenseurl: ''
-        }), done, function(errors) {
-          expect(_.size(errors)).to.be.equal(0);
-        });
+      postRoute(_.assign(sumbission, {
+        public: 'true',
+        openlicense: 'null',
+        licenseurl: ''
+      }), done, function(errors) {
+        expect(_.size(errors)).to.be.equal(0);
       });
+    });
 
     it('should return no error (public=null => openlicense=null; ' +
       'licenseurl: "")', function(done) {
-        postRoute(_.assign(sumbission, {
-          public: 'null',
-          openlicense: 'null',
-          licenseurl: ''
-        }), done, function(errors) {
-          expect(_.size(errors)).to.be.equal(0);
-        });
+      postRoute(_.assign(sumbission, {
+        public: 'null',
+        openlicense: 'null',
+        licenseurl: ''
+      }), done, function(errors) {
+        expect(_.size(errors)).to.be.equal(0);
       });
+    });
 
     it('should return no error (public=null => openlicense=false; ' +
       'licenseurl: "")', function(done) {
-        postRoute(_.assign(sumbission, {
-          public: 'null',
-          openlicense: 'false',
-          licenseurl: ''
-        }), done, function(errors) {
-          expect(_.size(errors)).to.be.equal(0);
-        });
+      postRoute(_.assign(sumbission, {
+        public: 'null',
+        openlicense: 'false',
+        licenseurl: ''
+      }), done, function(errors) {
+        expect(_.size(errors)).to.be.equal(0);
       });
+    });
 
     it('should return no error (public=null => openlicense=true)',
       function(done) {
@@ -222,7 +223,6 @@ describe('#validationData()', function() {
           openlicense: 'false',
           online: 'false',
           url: '',
-          openlicense: 'false',
           licenseurl: '',
           bulk: 'false'}
         ), done, function(errors) {
@@ -239,7 +239,6 @@ describe('#validationData()', function() {
           openlicense: 'false',
           online: 'false',
           url: '',
-          openlicense: 'false',
           licenseurl: '',
           bulk: 'false'}
         ), done, function(errors) {
@@ -257,7 +256,6 @@ describe('#validationData()', function() {
           openlicense: 'false',
           online: 'false',
           url: '',
-          openlicense: 'false',
           licenseurl: '',
           bulk: 'false'}
         ), done, function(errors) {
@@ -308,19 +306,18 @@ describe('#validationData()', function() {
         expect(_.size(errors)).to.be.equal(1);
       });
     });
-
   });
 
   describe('Edge cases', function() {
     it('should return error for exists and format (the fields are ' +
-      'not submitted)', function(done) {
-        postRoute(_.omit(sumbission, ['exists', 'format']), done,
-          function(errors) {
-            expect(errors).to.have.property('exists');
-            expect(errors).to.have.property('format');
-            expect(_.size(errors)).to.be.equal(2);
-          });
-      });
+    'not submitted)', function(done) {
+      postRoute(_.omit(sumbission, ['exists', 'format']), done,
+        function(errors) {
+          expect(errors).to.have.property('exists');
+          expect(errors).to.have.property('format');
+          expect(_.size(errors)).to.be.equal(2);
+        });
+    });
 
     it('should return error for openlicense (free=null => openlicense=null)',
       function(done) {
@@ -336,7 +333,7 @@ describe('#validationData()', function() {
     it('should return error for url, format, licenseurl ' +
        '(online = machinereadable = openlicense = false)', function(done) {
       postRoute(_.assign(sumbission, {
-        online: 'false', 'machinereadable': 'false', openlicense: 'false'
+        online: 'false', machinereadable: 'false', openlicense: 'false'
       }), done, function(errors) {
         expect(errors).to.have.property('url');
         expect(errors).to.have.property('format');
@@ -345,5 +342,4 @@ describe('#validationData()', function() {
       });
     });
   });
-
 });

--- a/tests/submissions.js
+++ b/tests/submissions.js
@@ -46,10 +46,10 @@ function postRoute(data, done, test) {
 }
 
 describe('#validationData()', function() {
-  var sumbission;
+  var submission;
 
   beforeEach(function() {
-    sumbission = {
+    submission = {
       place: 'ar',
       dataset: 'map',
       exists: 'true',
@@ -69,12 +69,12 @@ describe('#validationData()', function() {
 
   describe('General', function() {
     it('should not return errors', function(done) {
-      postRoute(sumbission, done, function(errors) {
+      postRoute(submission, done, function(errors) {
         expect(errors).to.be.eql({});
       });
     });
     it('should return place and dataset errors (empty values)', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         place: '',
         dataset: ''
       }), done, function(errors) {
@@ -84,7 +84,7 @@ describe('#validationData()', function() {
       });
     });
     it('should return exists, digital, url (invalid values)', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         digital: 'foo', online: 'bar', url: 'example'
       }), done, function(errors) {
         expect(errors).to.have.property('digital');
@@ -98,7 +98,7 @@ describe('#validationData()', function() {
   describe('Survey flow', function() {
     it('should return errors for online, machinereadable and ' +
         'bulk (digital=false)', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         digital: 'false'
       }), done, function(errors) {
         expect(errors).to.have.property('online');
@@ -109,7 +109,7 @@ describe('#validationData()', function() {
     });
     it('should return errors for free, openlicense (public=false)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           public: 'false'
         }), done, function(errors) {
           expect(errors).to.have.property('free');
@@ -118,20 +118,20 @@ describe('#validationData()', function() {
         });
       });
     it('should return error for openlicense (free=false)', function(done) {
-      postRoute(_.assign(sumbission, {free: 'false'}), done, function(errors) {
+      postRoute(_.assign(submission, {free: 'false'}), done, function(errors) {
         expect(errors).to.have.property('openlicense');
         expect(_.size(errors)).to.be.equal(1);
       });
     });
     it('should return error for empty url (online=true)', function(done) {
-      postRoute(_.assign(sumbission, {url: ''}), done, function(errors) {
+      postRoute(_.assign(submission, {url: ''}), done, function(errors) {
         expect(errors).to.have.property('url');
         expect(_.size(errors)).to.be.equal(1);
       });
     });
     it('should return error for empty licenseurl (openlicense=true)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           licenseurl: ''
         }), done, function(errors) {
           expect(errors).to.have.property('licenseurl');
@@ -140,7 +140,7 @@ describe('#validationData()', function() {
       });
     it('should return error for empty format (machinereadable=true)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           format: ''
         }), done, function(errors) {
           expect(errors).to.have.property('format');
@@ -152,7 +152,7 @@ describe('#validationData()', function() {
   describe('expectFalse cases', function() {
     it('should return no error (public=true => openlicense=true)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           public: 'true',
           openlicense: 'true'
         }), done, function(errors) {
@@ -162,7 +162,7 @@ describe('#validationData()', function() {
 
     it('should return no error (public=true => openlicense=false; ' +
       'licenseurl = "")', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         public: 'true',
         openlicense: 'false',
         licenseurl: ''
@@ -173,7 +173,7 @@ describe('#validationData()', function() {
 
     it('should return no error (public=true => openlicense=null; ' +
       'licenseurl: "")', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         public: 'true',
         openlicense: 'null',
         licenseurl: ''
@@ -184,7 +184,7 @@ describe('#validationData()', function() {
 
     it('should return no error (public=null => openlicense=null; ' +
       'licenseurl: "")', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         public: 'null',
         openlicense: 'null',
         licenseurl: ''
@@ -195,7 +195,7 @@ describe('#validationData()', function() {
 
     it('should return no error (public=null => openlicense=false; ' +
       'licenseurl: "")', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         public: 'null',
         openlicense: 'false',
         licenseurl: ''
@@ -206,7 +206,7 @@ describe('#validationData()', function() {
 
     it('should return no error (public=null => openlicense=true)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           public: 'null',
           openlicense: 'true'
         }), done, function(errors) {
@@ -217,7 +217,7 @@ describe('#validationData()', function() {
     it('should return no error (public=false => openlicense=false; ' +
       'online=false; free=false; openlicense=false; bulk=false)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           public: 'false',
           free: 'false',
           openlicense: 'false',
@@ -233,7 +233,7 @@ describe('#validationData()', function() {
     it('should return error for free (public=false => openlicense=false; ' +
       'online=false; free=true; openlicense=false; bulk=false)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           public: 'false',
           free: 'true',
           openlicense: 'false',
@@ -250,7 +250,7 @@ describe('#validationData()', function() {
     it('should return error for free (public=false => openlicense=false; ' +
       'online=false; free=null; openlicense=false; bulk=false)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           public: 'false',
           free: 'null',
           openlicense: 'false',
@@ -267,7 +267,7 @@ describe('#validationData()', function() {
     it('should return error for openlicense, licenseurl (public=false => ' +
       'openlicense=true; online=false; free=true; bulk=false)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           public: 'false',
           free: 'false',
           openlicense: 'true',
@@ -284,7 +284,7 @@ describe('#validationData()', function() {
 
     it('should return no error (exists=null => digital=null; ' +
       'public=null; uptodate=null)', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         exists: 'null',
         digital: 'null',
         public: 'null',
@@ -296,7 +296,7 @@ describe('#validationData()', function() {
 
     it('should return error for digital (exists=null => digital=true; ' +
       'public=null; uptodate=null)', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         exists: 'null',
         digital: 'true',
         public: 'null',
@@ -311,7 +311,7 @@ describe('#validationData()', function() {
   describe('Edge cases', function() {
     it('should return error for exists and format (the fields are ' +
     'not submitted)', function(done) {
-      postRoute(_.omit(sumbission, ['exists', 'format']), done,
+      postRoute(_.omit(submission, ['exists', 'format']), done,
         function(errors) {
           expect(errors).to.have.property('exists');
           expect(errors).to.have.property('format');
@@ -321,7 +321,7 @@ describe('#validationData()', function() {
 
     it('should return error for openlicense (free=null => openlicense=null)',
       function(done) {
-        postRoute(_.assign(sumbission, {
+        postRoute(_.assign(submission, {
           free: 'null',
           openlicense: 'null'
         }), done, function(errors) {
@@ -332,7 +332,7 @@ describe('#validationData()', function() {
 
     it('should return error for url, format, licenseurl ' +
        '(online = machinereadable = openlicense = false)', function(done) {
-      postRoute(_.assign(sumbission, {
+      postRoute(_.assign(submission, {
         online: 'false', machinereadable: 'false', openlicense: 'false'
       }), done, function(errors) {
         expect(errors).to.have.property('url');


### PR DESCRIPTION
`place` and `dataset` values were validated only for empty strings. This PR ensures the submitted values also correspond with valid existing ids in the database.

Most of the commits here are linting fluff. The meaningful work is in this commit: 7887a1a

Fixes #625 