### PR TITLE
Fix broken TOC in docs/site-admin 

### DIFF
--- a/docs/site-admins/index.md
+++ b/docs/site-admins/index.md
@@ -4,8 +4,9 @@ This is a short introduction to how to administer an Open Data Census.
 
 Note: it assumes that a census instance has been booted for you (and is __not__ about the technical side of deploying a census instance)
 
-* Table of contents
-{:toc}
+## Table of contents
+
+[TOC]
 
 ## Overview of How a Census is Structured
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,5 +15,6 @@ theme: readthedocs
 markdown_extensions:
   - markdown_include.include:
       base_path: docs
+  - toc:
 google_analytics: ['UA-33874954-7', 'census.okfn.org']
 


### PR DESCRIPTION
TOC element not rendering. Needs the extension enabling and correct syntax.

http://census.okfn.org/en/latest/site-admins/
