### PR TITLE
Disable datasets for specific years

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,3 +29,5 @@ rules:
     - warn
   no-unused-expressions:
     - off
+  new-cap:
+    - warn

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,3 +25,7 @@ rules:
     - warn
   no-else-return:
     - warn
+  camelcase:
+    - warn
+  no-unused-expressions:
+    - off

--- a/census/app.js
+++ b/census/app.js
@@ -125,7 +125,8 @@ function start() {
   routes.utils.setupAuth();
 
   return new Promise(function(resolve, reject) {
-    app.get('models').umzug.up().then(function() {
+    app.get('models').umzug.up()
+    .then(function() {
       var server = app.listen(app.get('port'), function() {
         console.log('Listening on ' + app.get('port'));
         resolve({

--- a/census/controllers/utils.js
+++ b/census/controllers/utils.js
@@ -192,12 +192,17 @@ var datasetMapper = function(data) {
   if (data.reviewers) {
     reviewers = splitFields(data.reviewers);
   }
+  var disableforyears = [];
+  if (data.disableforyears) {
+    disableforyears = splitFields(data.disableforyears);
+  }
   return _.defaults({
     id: data.id.toLowerCase(),
     description: marked(data.description),
     name: data.title,
     order: data.order || 100,
-    reviewers: reviewers
+    reviewers: reviewers,
+    disableforyears: disableforyears
   }, data);
 };
 

--- a/census/migrations/20160726143147-add-disableforyears.js
+++ b/census/migrations/20160726143147-add-disableforyears.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.addColumn('dataset', 'disableforyears',
+      {
+        type: Sequelize.ARRAY(Sequelize.STRING),
+        allowNull: true,
+        comment: 'Years for which dataset is disabled.'
+      });
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.removeColumn('dataset', 'disableforyears');
+  }
+};
+

--- a/census/models/dataset.js
+++ b/census/models/dataset.js
@@ -49,12 +49,16 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       comment: 'Dataset-specific reviewers.'
     },
+    disableforyears: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+      comment: 'Years for which dataset is disabled.'
+    },
     translations: {
       type: DataTypes.JSONB,
       allowNull: true
     }
-  },
-  {
+  }, {
     tableName: 'dataset',
     indexes: [
       {
@@ -79,8 +83,8 @@ module.exports = function(sequelize, DataTypes) {
         })));
         var score = count * questionMaxScore;
         return score;
-      },
-    },
+      }
+    }
   });
 
   return Dataset;

--- a/census/models/dataset.js
+++ b/census/models/dataset.js
@@ -77,10 +77,12 @@ module.exports = function(sequelize, DataTypes) {
       }
     },
     classMethods: {
+      /* Calculate the max score possible for all unique datasets used by a given list
+         of entries.*/
       maxScore: function(entries, questionMaxScore) {
-        var count = _.size(_.uniq(_.map(entries, function(entry) {
-          return entry.dataset;
-        })));
+        // number of unique datasets across the passed entries.
+        var count = _.size(_.uniq(_.map(entries, entry => entry.dataset)));
+        // max score possible across all unique datasets
         var score = count * questionMaxScore;
         return score;
       }

--- a/census/models/place.js
+++ b/census/models/place.js
@@ -46,8 +46,7 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.JSONB,
       allowNull: true
     }
-  },
-  {
+  }, {
     tableName: 'place',
     indexes: [
       {
@@ -66,14 +65,16 @@ module.exports = function(sequelize, DataTypes) {
       }
     },
     classMethods: {
+      /* Calculate the max score possible for all unique places used by a given list
+         of entries.*/
       maxScore: function(entries, questionMaxScore) {
-        var count = _.size(_.uniq(_.map(entries, function(entry) {
-          return entry.place;
-        })));
+        // number of unique places across the passed entries.
+        var count = _.size(_.uniq(_.map(entries, entry => entry.place)));
+        // max score possible across all unique places
         var score = count * questionMaxScore;
         return score;
-      },
-    },
+      }
+    }
   });
 
   return Place;

--- a/census/models/question.js
+++ b/census/models/question.js
@@ -63,8 +63,7 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.JSONB,
       allowNull: true
     }
-  },
-  {
+  }, {
     tableName: 'question',
     indexes: [
       {
@@ -75,12 +74,11 @@ module.exports = function(sequelize, DataTypes) {
       translated: mixins.translated
     },
     classMethods: {
+      /* Calculate the max score possible for a given list of questions */
       maxScore: function(questions) {
-        return _.sum(_.map(questions, function(question) {
-          return question.score;
-        }));
-      },
-    },
+        return _.sum(_.map(questions, question => question.score));
+      }
+    }
   });
 
   return Question;

--- a/census/models/utils.js
+++ b/census/models/utils.js
@@ -212,6 +212,34 @@ var rankDatasets = function(datasets) {
   return datasets;
 };
 
+/* Return the ids of excluded datasets for each year, as defined by the
+   disableforyears field.
+
+   Returns object in the form:
+
+   {
+      <year>: [<dataset_id>, <dataset_id>, ...],
+      <year>: [<dataset_id>, <dataset_id>, ...],
+      ...
+   }
+*/
+var excludedDatasetsByYear = function(data) {
+  let datasets = [];
+  if (data.dataset) {
+    datasets.push(data.dataset);
+  } else {
+    datasets = data.datasets;
+  }
+
+  let years = _.uniq(_.flatten(_.map(datasets, ds => ds.disableforyears)));
+
+  let excludedDatasetsObj = _.object(years, _.map(years, year =>
+    _.map(_.filter(datasets, ds => _.includes(ds.disableforyears, year)), 'id')
+  ));
+
+  return excludedDatasetsObj;
+};
+
 /*
  * Process the raw entries query.
  */

--- a/census/models/utils.js
+++ b/census/models/utils.js
@@ -253,14 +253,20 @@ var processEntries = function(data, options) {
       data.entries = cascadeEntries(data.entries, options.year);
     }
 
-    // Apply exclude filter
+    excludedDatasetsByYear(data);
+
+    // Apply exclude filters
     data.entries = _.reject(data.entries, function(entry) {
-      var result = false;
+      let result = false;
       if (options.exclude_datasets) {
         result = result || _.contains(options.exclude_datasets, entry.dataset);
       }
       if (options.exclude_places) {
         result = result || _.contains(options.exclude_places, entry.place);
+      }
+      if (options.year) {
+        let excludedForYear = excludedDatasetsByYear(data)[options.year];
+        result = result || _.contains(excludedForYear, entry.dataset);
       }
       return result;
     });
@@ -343,12 +349,18 @@ var processDatasets = function(data, options) {
     data.dataset = data.dataset.translated(options.locale);
   // Many datasets
   } else {
-    // Apply exclude filter
-    if (options.exclude_datasets) {
-      data.datasets = _.reject(data.datasets, function(dataset) {
-        return _.contains(options.exclude_datasets, dataset.id);
-      });
-    }
+    // Apply exclude filters
+    data.datasets = _.reject(data.datasets, dataset => {
+      let result = false;
+      if (options.exclude_datasets) {
+        result = result || _.contains(options.exclude_datasets, dataset.id);
+      }
+      if (options.year) {
+        let excludedForYear = excludedDatasetsByYear(data)[options.year];
+        result = result || _.contains(excludedForYear, dataset.id);
+      }
+      return result;
+    });
 
     // Add scores, translate
     if (Array.isArray(data.entries)) {

--- a/census/models/utils.js
+++ b/census/models/utils.js
@@ -231,7 +231,8 @@ var excludedDatasetsByYear = function(data) {
     datasets = data.datasets;
   }
 
-  let years = _.uniq(_.flatten(_.map(datasets, ds => ds.disableforyears)));
+  let years = _.uniq(_.flatten(_.map(datasets, 'disableforyears')));
+  years = _.reject(years, _.isNull);
 
   let excludedDatasetsObj = _.object(years, _.map(years, year =>
     _.map(_.filter(datasets, ds => _.includes(ds.disableforyears, year)), 'id')

--- a/fixtures/dataset.js
+++ b/fixtures/dataset.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var objects = [
   {
     model: 'Dataset',
@@ -17,6 +19,17 @@ var objects = [
       name: 'Dataset 12',
       description: 'Description of Dataset 12',
       order: 0
+    }
+  },
+  {
+    model: 'Dataset',
+    data: {
+      id: 'dataset13',
+      site: 'site1',
+      name: 'Dataset 13',
+      description: 'Description of Dataset 13',
+      order: 0,
+      disableforyears: ['2015']
     }
   },
   {

--- a/fixtures/entry.js
+++ b/fixtures/entry.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('underscore');
 var uuid = require('node-uuid');
 var datasets = require('./dataset');
@@ -152,6 +154,25 @@ var objects = [
       reviewComments: '',
       details: '',
       isCurrent: false,
+      submitterId: _.sample(users).data.id,
+      reviewerId: _.sample(users).data.id
+    }
+  },
+  {
+    model: 'Entry',
+    data: {
+      id: uuid.v4(),
+      site: 'site1',
+      year: 2015,
+      place: 'place11',
+      dataset: 'dataset13',
+      answers: answers(),
+      submissionNotes: '',
+      reviewed: true,
+      reviewResult: true,
+      reviewComments: '',
+      details: '',
+      isCurrent: true,
       submitterId: _.sample(users).data.id,
       reviewerId: _.sample(users).data.id
     }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mocha": "^2.2.5",
     "node-inspector": "^0.12.2",
     "optimist": "~0.6.1",
+    "rewire": "^2.5.2",
     "sinon": "^1.14.1",
     "supertest": "^1.0.1",
     "zombie": "^4.1.0"

--- a/tests/models.js
+++ b/tests/models.js
@@ -262,7 +262,18 @@ describe('Util function', function() {
       expect(excludedDatasets).to.have.all.keys('2013', '2016');
       expect(excludedDatasets).to.be.deep.equal({2013: ['id1'], 2016: ['id1']});
     });
+    it('returns empty object for single dataset with null disableforyears',
+    function() {
+      let data = {
+        dataset: {
+          id: 'id1',
+          disableforyears: null
+        }
+      };
 
+      let excludedDatasets = this.excludedDatasetsByYear(data);
+      expect(excludedDatasets).to.be.empty;
+    });
     it('returns empty object for array of datasets, all with empty disableforyears',
     function() {
       let data = {
@@ -274,6 +285,23 @@ describe('Util function', function() {
           {
             id: 'id2',
             disableforyears: []
+          }
+        ]
+      };
+      let excludedDatasets = this.excludedDatasetsByYear(data);
+      expect(excludedDatasets).to.be.empty;
+    });
+    it('returns empty object for array of datasets, all with null disableforyears',
+    function() {
+      let data = {
+        datasets: [
+          {
+            id: 'id1',
+            disableforyears: null
+          },
+          {
+            id: 'id2',
+            disableforyears: null
           }
         ]
       };
@@ -295,6 +323,10 @@ describe('Util function', function() {
           {
             id: 'id3',
             disableforyears: ['2014', '2015']
+          },
+          {
+            id: 'id4',
+            disableforyears: null
           }
         ]
       };

--- a/tests/models.js
+++ b/tests/models.js
@@ -228,6 +228,43 @@ describe('Data access layer', function() {
       expect(data.rejected).to.have.length(1);
     });
   });
+
+  it('excludes dataset if exclude_dataset option is present', function() {
+    var dataOptions = {
+      models: models,
+      domain: 'site1',
+      dataset: null,
+      place: null,
+      year: 2015,
+      cascade: true,
+      ynQuestions: true,
+      locale: null,
+      with: {Entry: true, Dataset: true, Place: true, Question: true},
+      exclude_datasets: ['dataset12']
+    };
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data.entries).to.have.length(2);
+      expect(data.datasets).to.have.length(1);
+    });
+  });
+
+  it('exclude dataset if disableforyears is set for year', function() {
+    var dataOptions = {
+      models: models,
+      domain: 'site1',
+      dataset: null,
+      place: null,
+      year: 2015,
+      cascade: true,
+      ynQuestions: true,
+      locale: null,
+      with: {Entry: true, Dataset: true, Place: true, Question: true}
+    };
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data.entries).to.have.length(3);
+      expect(data.datasets).to.have.length(2);
+    });
+  });
 });
 
 describe('Util function', function() {

--- a/tests/models.js
+++ b/tests/models.js
@@ -25,7 +25,7 @@ describe('Data access layer', function() {
   beforeEach(utils.setupFixtures);
   afterEach(utils.dropFixtures);
 
-  it('works with defaults', function(done) {
+  it('works with defaults', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -37,20 +37,17 @@ describe('Data access layer', function() {
       locale: null,
       with: {Entry: true, Dataset: true, Place: true, Question: true}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data).to.have.property('entries');
-        expect(data).to.have.property('pending');
-        expect(data).to.have.property('rejected');
-        expect(data).to.have.property('datasets');
-        expect(data).to.have.property('places');
-        expect(data).to.have.property('questions');
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data).to.have.property('entries');
+      expect(data).to.have.property('pending');
+      expect(data).to.have.property('rejected');
+      expect(data).to.have.property('datasets');
+      expect(data).to.have.property('places');
+      expect(data).to.have.property('questions');
+    });
   });
 
-  it('keepAll=true should return all entries', function(done) {
+  it('keepAll=true should return all entries', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -63,22 +60,19 @@ describe('Data access layer', function() {
       keepAll: true,
       with: {Entry: true, Dataset: false, Place: false, Question: false}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data).to.have.property('entries');
-        var hasCurrent = false;
-        var hasNonCurrent = false;
-        _.forEach(data.entries, function(entry) {
-          entry.isCurrent ? hasCurrent = true : hasNonCurrent = true;
-        });
-        expect(hasCurrent).to.be.true;
-        expect(hasNonCurrent).to.be.true;
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data).to.have.property('entries');
+      var hasCurrent = false;
+      var hasNonCurrent = false;
+      _.forEach(data.entries, entry => {
+        entry.isCurrent ? hasCurrent = true : hasNonCurrent = true;
+      });
+      expect(hasCurrent).to.be.true;
+      expect(hasNonCurrent).to.be.true;
+    });
   });
 
-  it('keepAll=false should return only current entries', function(done) {
+  it('keepAll=false should return only current entries', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -90,22 +84,19 @@ describe('Data access layer', function() {
       locale: null,
       with: {Entry: true, Dataset: false, Place: false, Question: false}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data).to.have.property('entries');
-        var hasCurrent = false;
-        var hasNonCurrent = false;
-        _.forEach(data.entries, function(entry) {
-          entry.isCurrent ? hasCurrent = true : hasNonCurrent = true;
-        });
-        expect(hasCurrent).to.be.true;
-        expect(hasNonCurrent).to.be.false;
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data).to.have.property('entries');
+      var hasCurrent = false;
+      var hasNonCurrent = false;
+      _.forEach(data.entries, entry => {
+        entry.isCurrent ? hasCurrent = true : hasNonCurrent = true;
+      });
+      expect(hasCurrent).to.be.true;
+      expect(hasNonCurrent).to.be.false;
+    });
   });
 
-  it('does not return results of an Entry query', function(done) {
+  it('does not return results of an Entry query', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -117,20 +108,17 @@ describe('Data access layer', function() {
       locale: null,
       with: {Entry: false, Dataset: true, Place: true, Question: true}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data).to.not.have.property('entries');
-        expect(data).to.not.have.property('pending');
-        expect(data).to.not.have.property('rejected');
-        expect(data).to.have.property('datasets');
-        expect(data).to.have.property('places');
-        expect(data).to.have.property('questions');
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data).to.not.have.property('entries');
+      expect(data).to.not.have.property('pending');
+      expect(data).to.not.have.property('rejected');
+      expect(data).to.have.property('datasets');
+      expect(data).to.have.property('places');
+      expect(data).to.have.property('questions');
+    });
   });
 
-  it('only returns yn questions by default', function(done) {
+  it('only returns yn questions by default', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -142,15 +130,12 @@ describe('Data access layer', function() {
       locale: null,
       with: {Entry: true, Dataset: true, Place: true, Question: true}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data.questions).to.have.length(9);
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data.questions).to.have.length(9);
+    });
   });
 
-  it('can return all questions', function(done) {
+  it('can return all questions', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -162,16 +147,13 @@ describe('Data access layer', function() {
       locale: null,
       with: {Entry: true, Dataset: true, Place: true, Question: true}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data.questions).to.have.length(18);
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data.questions).to.have.length(18);
+    });
   });
 
   it('returns a place and not places when we have a place argument',
-    function(done) {
+    function() {
       var dataOptions = {
         models: models,
         domain: 'site1',
@@ -183,17 +165,14 @@ describe('Data access layer', function() {
         locale: null,
         with: {Entry: true, Dataset: true, Place: true, Question: true}
       };
-      modelUtils.getData(dataOptions)
-        .then(function(data) {
-          expect(data).to.not.have.property('places');
-          expect(data).to.have.property('place');
-          done();
-        })
-        .catch(console.trace.bind(console));
+      return modelUtils.getData(dataOptions).then(function(data) {
+        expect(data).to.not.have.property('places');
+        expect(data).to.have.property('place');
+      });
     });
 
   it('returns a dataset and not datasets when we have a dataset argument',
-    function(done) {
+    function() {
       var dataOptions = {
         models: models,
         domain: 'site1',
@@ -205,16 +184,13 @@ describe('Data access layer', function() {
         locale: null,
         with: {Entry: true, Dataset: true, Place: true, Question: true}
       };
-      modelUtils.getData(dataOptions)
-        .then(function(data) {
-          expect(data).to.not.have.property('datasets');
-          expect(data).to.have.property('dataset');
-          done();
-        })
-        .catch(console.trace.bind(console));
+      return modelUtils.getData(dataOptions).then(function(data) {
+        expect(data).to.not.have.property('datasets');
+        expect(data).to.have.property('dataset');
+      });
     });
 
-  it('returns cascaded entries when cascade is true', function(done) {
+  it('returns cascaded entries when cascade is true', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -226,17 +202,14 @@ describe('Data access layer', function() {
       locale: null,
       with: {Entry: true, Dataset: true, Place: true, Question: true}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data.entries).to.have.length(3);
-        expect(data.pending).to.have.length(2);
-        expect(data.rejected).to.have.length(1);
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data.entries).to.have.length(3);
+      expect(data.pending).to.have.length(2);
+      expect(data.rejected).to.have.length(1);
+    });
   });
 
-  it('returns entries by year when cascade is false', function(done) {
+  it('returns entries by year when cascade is false', function() {
     var dataOptions = {
       models: models,
       domain: 'site1',
@@ -248,14 +221,10 @@ describe('Data access layer', function() {
       locale: null,
       with: {Entry: true, Dataset: true, Place: true, Question: true}
     };
-    modelUtils.getData(dataOptions)
-      .then(function(data) {
-        expect(data.entries).to.have.length(2);
-        expect(data.pending).to.have.length(2);
-        expect(data.rejected).to.have.length(1);
-        done();
-      })
-      .catch(console.trace.bind(console));
+    return modelUtils.getData(dataOptions).then(function(data) {
+      expect(data.entries).to.have.length(2);
+      expect(data.pending).to.have.length(2);
+      expect(data.rejected).to.have.length(1);
+    });
   });
-
 });


### PR DESCRIPTION
Fixes #754 

A new column is available, `disableForYears`, in the site config datasets spreadsheet that can take a string of years separated by commas, e.g. `2013,2014`.

Once loaded into a site, this will populate the db column `disableforyears` with an array of years.

The `disableforyears` property will be used to filter out datasets when processing data in `models/utils.js`; specifically in the `processDatasets` and `processEntries` functions.

Processing data in this way excludes datasets from the front-end views for specified years.

Disabled datasets are excluded from scoring calculations.