### PR TITLE
Sanitise inputs when loading data from google spreadsheets

### DIFF
--- a/census/loaders/utils.js
+++ b/census/loaders/utils.js
@@ -2,6 +2,7 @@
 
 var Promise = require('bluebird');
 var request = require('request');
+var xss = require('xss');
 var csv = require('csv');
 
 var spreadsheetParse = function(fileUrl) {
@@ -50,14 +51,13 @@ var _mapParsedCsvData = function(parsedData) {
   for (var i = 0; i < parsedData.length; i++) {
     if (i === 0) {
       for (var j = 0; j < parsedData[i].length; j++) {
-        var key = parsedData[i][j].toLowerCase();
+        var key = xss(parsedData[i][j].toLowerCase());
         keys.push(key);
       }
     } else {
       var object = {};
       for (var n = 0; n < keys.length; n++) {
-        object[keys[n]] = parsedData[i][n];
-
+        object[keys[n]] = xss(parsedData[i][n]);
       }
       result.push(object);
     }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "throng": "^1.0.0",
     "umzug": "^1.6.0",
     "underscore": "^1.8.3",
-    "validator": "^3.41.2"
+    "validator": "^3.41.2",
+    "xss": "^0.2.13"
   },
   "devDependencies": {
     "chai": "^2.1.4",


### PR DESCRIPTION
A basic precaution to sanitise inputs when loading data from google spreadsheet resources, using the [xss](https://www.npmjs.com/package/xss) library. This will allow HTML, but prevent things like script tags.