### PR TITLE
Add QuestionFieldMultipleChoice React component

### DIFF
--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -252,6 +252,7 @@ var submitReact = function(req, res) {
       questionsPromise = currentDataset.getQuestions();
     }
     Promise.join(qsSchemaPromise, questionsPromise, (qsSchema, questions) => {
+      if (qsSchema === undefined) qsSchema = [];
       questions = _.map(questions, question => {
         return {
           id: question.id,

--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -247,9 +247,13 @@ var submitReact = function(req, res) {
     let datasets = modelUtils.translateSet(req, data.datasets);
     let qsSchemaPromise;
     let questionsPromise;
+    let datasetContext = {};
     if (currentDataset) {
       qsSchemaPromise = currentDataset.getQuestionSetSchema();
       questionsPromise = currentDataset.getQuestions();
+      datasetContext = _.assign(datasetContext, {
+        characteristics: currentDataset.characteristics
+      });
     }
     Promise.join(qsSchemaPromise, questionsPromise, (qsSchema, questions) => {
       if (qsSchema === undefined) qsSchema = [];
@@ -266,13 +270,15 @@ var submitReact = function(req, res) {
       let initialHTML = renderToString(
         <QuestionForm questions={questions}
                       qsSchema={qsSchema}
-                      labelPrefix={'B'} />
+                      labelPrefix={'B'}
+                      context={datasetContext} />
       );
       res.render('create-react.html', {
         places: places,
         datasets: datasets,
         qsSchema: JSON.stringify(qsSchema),
         questions: JSON.stringify(questions),
+        datasetContext: JSON.stringify(datasetContext),
         current: data.currentState.match,
         initialRenderedQuestions: initialHTML,
         breadcrumbTitle: 'Make a Submission'

--- a/census/ui_app/QuestionFields.jsx
+++ b/census/ui_app/QuestionFields.jsx
@@ -261,9 +261,94 @@ let QuestionFieldSource = React.createClass({
 });
 QuestionFieldSource = baseQuestionField(QuestionFieldSource);
 
+const QuestionFieldMultipleChoiceOption = props => {
+  return (
+    <li>
+      <input type="checkbox"
+             name={props.id}
+             id={props.id}
+             value="1"
+             checked={props.checked}
+             onChange={props.handler} />
+      <label htmlFor={props.id}>
+        <span className="letter">{props.label}</span> <span className="description">{props.children.toString()}</span>
+      </label>
+    </li>
+  );
+};
+
+let QuestionFieldMultipleChoice = React.createClass({
+  getDefaultOptionsForCharacteristics(characteristics) {
+    return _.map(characteristics, char => {
+      return {description: char, checked: false};
+    });
+  },
+
+  componentWillMount() {
+    // Set the defaultCharacteristics collection, either from a list of
+    // `options` in the Question's config, or from the context using a key
+    // defined in the Question's config (`optionsContextKey`).
+    let defaultCharacteristics = [];
+    if (_.has(this.props.config, 'optionsContextKey')) {
+      // Config directs to get the value from the context for the key set in
+      // `optionsContextKey`.
+      let contextCharacteristics =
+        this.props.context[this.props.config.optionsContextKey];
+      defaultCharacteristics =
+        this.getDefaultOptionsForCharacteristics(contextCharacteristics);
+    }
+    if (_.has(this.props.config, 'options')) {
+      // Config has a list of options to use directly.
+      defaultCharacteristics =
+        this.getDefaultOptionsForCharacteristics(this.props.config.options);
+    }
+    // Merge the defaultCharacteristics with those from the value in props to
+    // get the value store we'll use for the render.
+    this.optionValues = _.assign(defaultCharacteristics, this.props.value);
+  },
+
+  render() {
+    let choices = _.map(this.optionValues, (option, i) => {
+      // i ==> letter, good for the first 26 options!
+      let label = String.fromCharCode(97 + i).toUpperCase();
+      return <QuestionFieldMultipleChoiceOption key={i}
+                                                id={this.props.id + i}
+                                                checked={option.checked}
+                                                label={label}
+                                                handler={this.handler.bind(this, i)}>
+                {option.description}
+              </QuestionFieldMultipleChoiceOption>;
+    });
+    return (<div className={'multiple question ' + this.props.getClassValues()}>
+      <QuestionInstructions instructionText={this.props.instructions}
+                            id={this.props.id} />
+      <div className="main">
+        <QuestionHeader label={this.props.label}>
+          {this.props.children.toString()}
+        </QuestionHeader>
+        <div className="answer">
+          <ul>
+            {choices}
+          </ul>
+        </div>
+      </div>
+      <QuestionComments id={this.props.id}
+                        placeholder={this.props.placeholder} />
+    </div>);
+  },
+
+  handler(i, e) {
+    let newOptionValues = this.optionValues;
+    newOptionValues[i].checked = e.target.checked;
+    this.props.onChange(this, newOptionValues);
+  }
+});
+QuestionFieldMultipleChoice = baseQuestionField(QuestionFieldMultipleChoice);
+
 export {
   QuestionFieldText,
   QuestionFieldYesNo,
   QuestionFieldLikert,
-  QuestionFieldSource
+  QuestionFieldSource,
+  QuestionFieldMultipleChoice
 };

--- a/census/ui_app/QuestionFields.jsx
+++ b/census/ui_app/QuestionFields.jsx
@@ -278,33 +278,33 @@ const QuestionFieldMultipleChoiceOption = props => {
 };
 
 let QuestionFieldMultipleChoice = React.createClass({
-  getDefaultOptionsForCharacteristics(characteristics) {
-    return _.map(characteristics, char => {
-      return {description: char, checked: false};
+  getDefaultOptionValuesForOptionList(optionList) {
+    return _.map(optionList, option => {
+      return {description: option, checked: false};
     });
   },
 
   componentWillMount() {
-    // Set the defaultCharacteristics collection, either from a list of
+    // Set the defaultOptions collection, either from a list of
     // `options` in the Question's config, or from the context using a key
     // defined in the Question's config (`optionsContextKey`).
-    let defaultCharacteristics = [];
+    let defaultOptions = [];
     if (_.has(this.props.config, 'optionsContextKey')) {
       // Config directs to get the value from the context for the key set in
       // `optionsContextKey`.
-      let contextCharacteristics =
+      let contextOptions =
         this.props.context[this.props.config.optionsContextKey];
-      defaultCharacteristics =
-        this.getDefaultOptionsForCharacteristics(contextCharacteristics);
+      defaultOptions =
+        this.getDefaultOptionValuesForOptionList(contextOptions);
     }
     if (_.has(this.props.config, 'options')) {
       // Config has a list of options to use directly.
-      defaultCharacteristics =
-        this.getDefaultOptionsForCharacteristics(this.props.config.options);
+      defaultOptions =
+        this.getDefaultOptionValuesForOptionList(this.props.config.options);
     }
-    // Merge the defaultCharacteristics with those from the value in props to
+    // Merge the defaultOptions with those from the value in props to
     // get the value store we'll use for the render.
-    this.optionValues = _.assign(defaultCharacteristics, this.props.value);
+    this.optionValues = _.assign(defaultOptions, this.props.value);
   },
 
   render() {

--- a/census/ui_app/QuestionForm.jsx
+++ b/census/ui_app/QuestionForm.jsx
@@ -134,7 +134,8 @@ const QuestionForm = React.createClass({
         yesno: fields.QuestionFieldYesNo,
         text: fields.QuestionFieldText,
         likert: fields.QuestionFieldLikert,
-        source: fields.QuestionFieldSource
+        source: fields.QuestionFieldSource,
+        multiple: fields.QuestionFieldMultipleChoice
       };
       const type = this.getValueForId(q.id, 'type');
       let ComponentClass = typesToComponent.yesno;
@@ -159,7 +160,7 @@ const QuestionForm = React.createClass({
                         config={
                           this.getValueForId(q.id, 'config')
                         }
-                        context={this.context}>
+                        context={this.props.context}>
           {this.getValueForId(q.id, 'text')}
         </ComponentClass>
       );

--- a/census/ui_app/QuestionForm.jsx
+++ b/census/ui_app/QuestionForm.jsx
@@ -10,7 +10,7 @@ const QuestionForm = React.createClass({
   },
 
   getInitialState() {
-    var questionValues = this.props.questions.map(q => {
+    let questionValues = this.props.questions.map(q => {
       return {
         id: q.id,
         value: ''
@@ -23,7 +23,7 @@ const QuestionForm = React.createClass({
 
   onFieldChange(field, value) {
     // Set the new value for the field
-    var newQuestionsState = _.map(this.state.questionState, qState => {
+    let newQuestionsState = _.map(this.state.questionState, qState => {
       if (qState.id === field.props.id) qState.value = value;
       return qState;
     });
@@ -47,22 +47,22 @@ const QuestionForm = React.createClass({
       For the sake of clarity, `dependant` objects depend on `provider`
       objects.
     */
-    var schema = this.getSchemaForId(id);
+    let schema = this.getSchemaForId(id);
     if (schema === undefined) return {};
 
     // Initially set up return value as the defaultProperties for the schema
-    var visProps = _.cloneDeep(schema.defaultProperties);
+    let visProps = _.cloneDeep(schema.defaultProperties);
 
     // For each dependency in the `if` array in the schema
     _.each(schema.if, dependency => {
       // Find the current state of the provider
-      var currentProviderState =
+      let currentProviderState =
         _.find(this.state.questionState,
                qState => qState.id === dependency.providerId);
 
       // If the actual value of the provider field is the same as the expected
       // value, and the provider field is enabled and visible...
-      var providerVisProps =
+      let providerVisProps =
         this.getVisiblePropsForId(dependency.providerId);
       if (currentProviderState.value === dependency.value &&
           providerVisProps.enabled &&
@@ -86,7 +86,7 @@ const QuestionForm = React.createClass({
       Return a label for the question schema with `id` (including optional
       prefix), derived from the schema position property.
     */
-    var schema = this.getSchemaForId(id);
+    let schema = this.getSchemaForId(id);
     if (schema === undefined) return;
     return String(this.props.labelPrefix || '') + String(schema.position) + '.';
   },
@@ -95,13 +95,13 @@ const QuestionForm = React.createClass({
     /*
       Return the position for the question schema with `id`.
     */
-    var schema = this.getSchemaForId(id);
+    let schema = this.getSchemaForId(id);
     if (schema === undefined) return;
     return schema.position;
   },
 
   render() {
-    var questionNodes = this.state.questionState.map(q => {
+    let questionNodes = this.state.questionState.map(q => {
       // check schema
       if (this.getSchemaForId(q.id) === undefined) {
         console.warn('No schema defined for Question with id: ' + q.id);

--- a/census/ui_app/QuestionForm.jsx
+++ b/census/ui_app/QuestionForm.jsx
@@ -6,7 +6,8 @@ const QuestionForm = React.createClass({
 
   propTypes: {
     questions: React.PropTypes.array.isRequired,
-    qsSchema: React.PropTypes.array.isRequired
+    qsSchema: React.PropTypes.array.isRequired,
+    context: React.PropTypes.object.isRequired
   },
 
   getInitialState() {
@@ -157,7 +158,8 @@ const QuestionForm = React.createClass({
                         }
                         config={
                           this.getValueForId(q.id, 'config')
-                        }>
+                        }
+                        context={this.context}>
           {this.getValueForId(q.id, 'text')}
         </ComponentClass>
       );

--- a/census/ui_app/QuestionForm.jsx
+++ b/census/ui_app/QuestionForm.jsx
@@ -38,6 +38,27 @@ const QuestionForm = React.createClass({
     return _.find(this.props.qsSchema, qSchema => qSchema.id === id);
   },
 
+  canAssignProperties(currentProviderState, dependency) {
+    /*
+      Determine if the passed dependency should assign visible properties
+      based on the currentProviderState object.
+
+      dependency objects can have a `value` property, which compares against
+      the currentProviderState.value, or a `isNotEmpty` property, which is
+      used to check whether currentProviderState.value is empty or not.
+    */
+    let canAssign = false;
+    if (_.has(dependency, 'value') &&
+        currentProviderState.value === dependency.value) {
+      canAssign = true;
+    }
+    if (_.has(dependency, 'isNotEmpty') &&
+        dependency.isNotEmpty === !_.isEmpty(currentProviderState.value)) {
+      canAssign = true;
+    }
+    return canAssign;
+  },
+
   getVisiblePropsForId(id) {
     /*
       Return visible properties (required, enabled, visible) for the question
@@ -64,7 +85,8 @@ const QuestionForm = React.createClass({
       // value, and the provider field is enabled and visible...
       let providerVisProps =
         this.getVisiblePropsForId(dependency.providerId);
-      if (currentProviderState.value === dependency.value &&
+
+      if (this.canAssignProperties(currentProviderState, dependency) &&
           providerVisProps.enabled &&
           providerVisProps.visible) {
         // Update the return value with the dependency properties.

--- a/census/ui_app/entry.jsx
+++ b/census/ui_app/entry.jsx
@@ -8,7 +8,7 @@ let questions = window.questions;
 
 $(function() {
   // Reload page with Dataset QuestionSet if dataset is changed.
-  $('#dataset-select, #place-select').change(function(e) {
+  $('#dataset-select').change(function(e) {
     e.preventDefault();
     let form = $(this).parents('form:first');
     form.submit();

--- a/census/ui_app/entry.jsx
+++ b/census/ui_app/entry.jsx
@@ -5,6 +5,7 @@ import $ from 'jquery';
 
 let qsSchema = window.qsSchema;
 let questions = window.questions;
+let datasetContext = window.datasetContext;
 
 $(function() {
   // Reload page with Dataset QuestionSet if dataset is changed.
@@ -18,5 +19,6 @@ $(function() {
 // Main QuestionSet, section B.
 render(<QuestionForm questions={questions}
                      qsSchema={qsSchema}
-                     labelPrefix={'B'} />,
+                     labelPrefix={'B'}
+                     context={datasetContext} />,
        document.getElementById('questions'));

--- a/census/views/create-react.html
+++ b/census/views/create-react.html
@@ -134,6 +134,7 @@
     <script type="text/javascript">
       window.qsSchema = {{ qsSchema|safe }};
       window.questions = {{ questions|safe }};
+      window.datasetContext = {{ datasetContext|safe }};
     </script>
   </div>
 </section>

--- a/tests/question_form.js
+++ b/tests/question_form.js
@@ -6,6 +6,7 @@ require('jsdom-global')();
 const _ = require('lodash');
 const React = require('react'); // eslint-disable-line no-unused-vars
 const mount = require('enzyme').mount;
+const shallow = require('enzyme').shallow;
 const expect = require('chai').expect;
 const QuestionForm = require('../census/ui_app/QuestionForm');
 
@@ -405,6 +406,92 @@ describe('<QuestionForm />', () => {
       expect(this.wrapper.ref('doctor_away').prop('visibleProps').required).is.false;
       expect(this.wrapper.ref('doctor_away').prop('visibleProps').enabled).is.true;
       expect(this.wrapper.ref('doctor_away').prop('visibleProps').visible).is.true;
+    });
+  });
+
+  describe.only('QuestionForm.canAssignProperties returns as expected', function() {
+    beforeEach(function () {
+      // Very basic QuestionForm
+      this.questionForm = shallow(<QuestionForm questions={[]} qsSchema={[]} />);
+    });
+    it('returns false if dependency and currentState are empty', function() {
+      let currentState = {};
+      let dependency = {};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+    it('returns true if dependency.value and currentState.value are the same', function() {
+      let currentState = {value: 'my-value'};
+      let dependency = {value: 'my-value'};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.true;
+    });
+    it('returns false if dependency.value and currentState.value are different', function() {
+      let currentState = {value: 'my-value'};
+      let dependency = {value: 'my-other-value'};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+
+    it('returns false if dependency.isNotEmpty and currentState.value is empty string', function() {
+      let currentState = {value: ''};
+      let dependency = {isNotEmpty: true};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+    it('returns false if dependency.isNotEmpty and currentState.value is empty array', function() {
+      let currentState = {value: []};
+      let dependency = {isNotEmpty: true};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+    it('returns false if dependency.isNotEmpty and currentState.value is empty object', function() {
+      let currentState = {value: {}};
+      let dependency = {isNotEmpty: true};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+
+    it('returns true if dependency.isNotEmpty and currentState.value is not empty string', function() {
+      let currentState = {value: 'not empty'};
+      let dependency = {isNotEmpty: true};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.true;
+    });
+    it('returns true if dependency.isNotEmpty and currentState.value is not empty array', function() {
+      let currentState = {value: ['a', 'b']};
+      let dependency = {isNotEmpty: true};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.true;
+    });
+    it('returns true if dependency.isNotEmpty and currentState.value is not empty object', function() {
+      let currentState = {value: {a: 'hi'}};
+      let dependency = {isNotEmpty: true};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.true;
+    });
+
+    it('returns false if dependency.isNotEmpty is false and currentState.value is not empty string', function() {
+      let currentState = {value: 'not empty'};
+      let dependency = {isNotEmpty: false};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+    it('returns false if dependency.isNotEmpty is false and currentState.value is not empty array', function() {
+      let currentState = {value: ['a', 'b']};
+      let dependency = {isNotEmpty: false};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+    it('returns false if dependency.isNotEmpty is false and currentState.value is not empty object', function() {
+      let currentState = {value: {a: 'hi'}};
+      let dependency = {isNotEmpty: false};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.false;
+    });
+
+    it('returns true if dependency.isNotEmpty is false and currentState.value is empty string', function() {
+      let currentState = {value: ''};
+      let dependency = {isNotEmpty: false};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.true;
+    });
+    it('returns true if dependency.isNotEmpty is false and currentState.value is empty array', function() {
+      let currentState = {value: []};
+      let dependency = {isNotEmpty: false};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.true;
+    });
+    it('returns true if dependency.isNotEmpty is false and currentState.value is empty object', function() {
+      let currentState = {value: {}};
+      let dependency = {isNotEmpty: false};
+      expect(this.questionForm.instance().canAssignProperties(currentState, dependency)).to.be.true;
     });
   });
 });

--- a/tests/question_form.js
+++ b/tests/question_form.js
@@ -69,6 +69,35 @@ describe('<QuestionForm />', () => {
       // Default has one empty line.
       expect(this.wrapper.find('QuestionFieldSourceLine')).to.have.length(1);
     });
+    it('renders QuestionFieldMultipleChoice type with options in config', function() {
+      let question = {
+        type: 'multiple',
+        config: {
+          options: ['txt', 'json', 'xls', 'xml']
+        }
+      };
+      this.baseQuestions[0] = _.assign(this.baseQuestions[0], question);
+      this.wrapper =
+        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} context={{}} />);
+      expect(this.wrapper.find('QuestionFieldMultipleChoice')).to.have.length(1);
+      expect(this.wrapper.find('QuestionFieldMultipleChoiceOption')).to.have.length(4);
+    });
+    it('renders QuestionFieldMultipleChoice type with optionsContextKey in config', function() {
+      let question = {
+        type: 'multiple',
+        config: {
+          optionsContextKey: 'characteristics'
+        }
+      };
+      let context = {
+        characteristics: ['txt', 'json', 'xml']
+      };
+      this.baseQuestions[0] = _.assign(this.baseQuestions[0], question);
+      this.wrapper =
+        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} context={context} />);
+      expect(this.wrapper.find('QuestionFieldMultipleChoice')).to.have.length(1);
+      expect(this.wrapper.find('QuestionFieldMultipleChoiceOption')).to.have.length(3);
+    });
   });
 
   let qsSchema = [

--- a/tests/question_form.js
+++ b/tests/question_form.js
@@ -35,14 +35,14 @@ describe('<QuestionForm />', () => {
 
     it('renders QuestionFieldYesNo type', function() {
       this.wrapper =
-        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} />);
+        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} context={{}} />);
       expect(this.wrapper.find('QuestionFieldYesNo')).to.have.length(1);
     });
     it('renders QuestionFieldText type', function() {
       // Replace `type` in baseQuestions.
       this.baseQuestions[0] = _.assign(this.baseQuestions[0], {type: 'text'});
       this.wrapper =
-        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} />);
+        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} context={{}} />);
       expect(this.wrapper.find('QuestionFieldText')).to.have.length(1);
     });
     it('renders QuestionFieldLikert type', function() {
@@ -54,7 +54,7 @@ describe('<QuestionForm />', () => {
       ]};
       this.baseQuestions[0] = _.assign(this.baseQuestions[0], question);
       this.wrapper =
-        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} />);
+        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} context={{}} />);
       expect(this.wrapper.find('QuestionFieldLikert')).to.have.length(1);
       // Scale has three options.
       expect(this.wrapper.find('QuestionFieldLikertOption')).to.have.length(3);
@@ -64,7 +64,7 @@ describe('<QuestionForm />', () => {
       let question = {type: 'source'};
       this.baseQuestions[0] = _.assign(this.baseQuestions[0], question);
       this.wrapper =
-        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} />);
+        mount(<QuestionForm questions={this.baseQuestions} qsSchema={this.baseQSSchema} context={{}} />);
       expect(this.wrapper.find('QuestionFieldSource')).to.have.length(1);
       // Default has one empty line.
       expect(this.wrapper.find('QuestionFieldSourceLine')).to.have.length(1);
@@ -191,7 +191,7 @@ describe('<QuestionForm />', () => {
   describe('QuestionFields have correct initial state', function() {
     beforeEach(function () {
       this.wrapper =
-        mount(<QuestionForm questions={questions} qsSchema={qsSchema} />);
+        mount(<QuestionForm questions={questions} qsSchema={qsSchema} context={{}} context={{}} />);
     });
 
     it('renders list of Questions', function() {
@@ -237,7 +237,7 @@ describe('<QuestionForm />', () => {
   describe('QuestionFields have correct state after Q1. "Yes"', function() {
     beforeEach(function () {
       this.wrapper =
-        mount(<QuestionForm questions={questions} qsSchema={qsSchema} />);
+        mount(<QuestionForm questions={questions} qsSchema={qsSchema} context={{}} />);
       this.wrapper.ref('like_apples').find('input[value="Yes"]').simulate('change');
     });
 
@@ -280,7 +280,7 @@ describe('<QuestionForm />', () => {
   describe('QuestionFields have correct state after Q1. "No"', function() {
     beforeEach(function () {
       this.wrapper =
-        mount(<QuestionForm questions={questions} qsSchema={qsSchema} />);
+        mount(<QuestionForm questions={questions} qsSchema={qsSchema} context={{}} />);
       this.wrapper.ref('like_apples').find('input[value="No"]').simulate('change');
     });
 
@@ -323,7 +323,7 @@ describe('<QuestionForm />', () => {
   describe('QuestionFields have correct state after Q1. "Yes" Q2. "Yes', function() {
     beforeEach(function () {
       this.wrapper =
-        mount(<QuestionForm questions={questions} qsSchema={qsSchema} />);
+        mount(<QuestionForm questions={questions} qsSchema={qsSchema} context={{}} />);
       this.wrapper.ref('like_apples').find('input[value="Yes"]').simulate('change');
       this.wrapper.ref('apple_colour').find('input[value="Yes"]').simulate('change');
     });
@@ -367,7 +367,7 @@ describe('<QuestionForm />', () => {
   describe('QuestionFields have correct state after Q1. "Yes" Q2. "Yes" Q4. "Yes"', function() {
     beforeEach(function () {
       this.wrapper =
-        mount(<QuestionForm questions={questions} qsSchema={qsSchema} />);
+        mount(<QuestionForm questions={questions} qsSchema={qsSchema} context={{}} />);
       this.wrapper.ref('like_apples').find('input[value="Yes"]').simulate('change');
       this.wrapper.ref('apple_colour').find('input[value="Yes"]').simulate('change');
       this.wrapper.ref('red_apple_today').find('input[value="Yes"]').simulate('change');
@@ -409,10 +409,10 @@ describe('<QuestionForm />', () => {
     });
   });
 
-  describe.only('QuestionForm.canAssignProperties returns as expected', function() {
+  describe('QuestionForm.canAssignProperties returns as expected', function() {
     beforeEach(function () {
       // Very basic QuestionForm
-      this.questionForm = shallow(<QuestionForm questions={[]} qsSchema={[]} />);
+      this.questionForm = shallow(<QuestionForm questions={[]} qsSchema={[]} context={{}} />);
     });
     it('returns false if dependency and currentState are empty', function() {
       let currentState = {};


### PR DESCRIPTION
This PR adds a new QuestionFieldMultipleChoice component, to allow users to select from a number of options. This forms part of the "Implement all Question types" requirement of #753.

<img width="942" alt="multiplechoice" src="https://cloud.githubusercontent.com/assets/3993/18990560/c22b9b8e-870a-11e6-906e-6b0a2676abe6.png">

(the design is currently a little squiffy for multi-line options)

Options can be defined in one of two ways:

A) By adding an array of options directly in the config object for the question:

```json
{
    "options": ["Option 1", "Option 2" "Option 3"]
}
```

B) By retrieving an array from the context object passed to the component, the key for which is defined in the question config object. For example, to use the array of dataset characteristics (which is passed in the context object), the config object would be defined:

```json
{
    "optionsContextKey": "characteristics"
}
```

Additionally! This PR adds a way for questions to change their visibility if their provider question has any value (is not empty). Previously, the exact value had to be defined. The `if` condition in the question set schema can now accept `isNotEmpty: <bool>` as its matching condition. This means question B can become visible if the text question, A, is filled in, regardless of what the value of A actually is.