### PR TITLE
More dataset context info in the entry form

### DIFF
--- a/MigrationNotes.md
+++ b/MigrationNotes.md
@@ -6,6 +6,8 @@ In the old codebase, Questions were associated with Datasets at the site level, 
 
 In the CMS, the Datasets sheet has a new `QuestionSetURL` column. The value is the url pointing to the `QuestionSet` config sheet. A site-wide Question Set url can be added to the site config page under the key `question_set_url`. A further system-wide fallback Question Set url can be set as an env var, `FALLBACK_QUESTIONSET` (this is provided for backward-compatibility to smooth migration to the new system).
 
+Datasets also have a new `UpdateEvery` column. The value for each cell in this column should be a time interval as a string in the question: "Data should be updated every {{ time interval }}." E.g. year, month, 6 months, day, second Thursday, etc. 
+
 The new Question Set config sheet is like the `Site` config. It has `key` and `value` columns. It expects a `questions` key, the value is the url the questions sheet, and a `question_set_schema` key, the value is the question set schema in json format (see the [Question Set Schema](#question-set-schema-json-format) section below).
 
 ### Extra Question Config

--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -7,6 +7,7 @@ const uuid = require('node-uuid');
 const utils = require('./utils');
 const modelUtils = require('../models').utils;
 const Promise = require('bluebird');
+const nunjucks = require('nunjucks');
 const React = require('react'); // eslint-disable-line no-unused-vars
 const renderToString = require('react-dom/server').renderToString;
 const QuestionForm = require('../ui_app/QuestionForm');
@@ -253,7 +254,8 @@ var submitReact = function(req, res) {
       questionsPromise = currentDataset.getQuestions();
       datasetContext = _.assign(datasetContext, {
         characteristics: currentDataset.characteristics,
-        datasetName: currentDataset.name
+        datasetName: currentDataset.name,
+        updateEvery: currentDataset.updateevery
       });
     }
     Promise.join(qsSchemaPromise, questionsPromise, (qsSchema, questions) => {
@@ -261,9 +263,11 @@ var submitReact = function(req, res) {
       questions = _.map(questions, question => {
         return {
           id: question.id,
-          text: question.question,
+          text: nunjucks.renderString(question.question,
+                                      {datasetContext: datasetContext}),
           type: question.type,
-          description: question.description,
+          description: nunjucks.renderString(question.description,
+                                             {datasetContext: datasetContext}),
           placeholder: question.placeholder,
           config: question.config
         };

--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -252,7 +252,8 @@ var submitReact = function(req, res) {
       qsSchemaPromise = currentDataset.getQuestionSetSchema();
       questionsPromise = currentDataset.getQuestions();
       datasetContext = _.assign(datasetContext, {
-        characteristics: currentDataset.characteristics
+        characteristics: currentDataset.characteristics,
+        datasetName: currentDataset.name
       });
     }
     Promise.join(qsSchemaPromise, questionsPromise, (qsSchema, questions) => {
@@ -278,7 +279,7 @@ var submitReact = function(req, res) {
         datasets: datasets,
         qsSchema: JSON.stringify(qsSchema),
         questions: JSON.stringify(questions),
-        datasetContext: JSON.stringify(datasetContext),
+        datasetContext: datasetContext,
         current: data.currentState.match,
         initialRenderedQuestions: initialHTML,
         breadcrumbTitle: 'Make a Submission'

--- a/census/controllers/utils.js
+++ b/census/controllers/utils.js
@@ -215,6 +215,7 @@ var datasetMapper = function(data, site) {
     reviewers: reviewers,
     disableforyears: disableforyears,
     characteristics: characteristics,
+    updateevery: data.updateevery,
     qsurl: qsurl
   }, data);
 };

--- a/census/migrations/20161003115501-add-dataset-update-every.js
+++ b/census/migrations/20161003115501-add-dataset-update-every.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.addColumn('dataset', 'updateevery',
+      {
+        type: Sequelize.STRING(),
+        allowNull: true,
+        comment: 'A time interval to determine timeliness for the dataset.'
+      });
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.removeColumn('dataset', 'updateevery');
+  }
+};

--- a/census/models/dataset.js
+++ b/census/models/dataset.js
@@ -59,6 +59,11 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: true,
       comment: 'An array of dataset characterstics.'
     },
+    updateevery: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      comment: 'A time interval to determine timeliness for the dataset.'
+    },
     qsurl: {
       type: DataTypes.STRING,
       allowNull: true,

--- a/census/views/create-react.html
+++ b/census/views/create-react.html
@@ -49,6 +49,7 @@
 </section>
 </form>
 
+{% if datasetContext|length %}
 <form action="." method="post" accept-charset="utf-8">
 <section>
   <div class="container">
@@ -60,7 +61,7 @@
     <div class="scale first question">
       <div class="instructions"></div>
       <div class="main">
-        <h2><span>A1.</span> Rate your knowledge of {...}.</h2>
+        <h2><span>A1.</span> Rate your knowledge of <em>{{ datasetContext.datasetName }}</em>.</h2>
         <div class="answer">
           <span>
             <input type="radio" name="scaleOne" id="scaleOne1">
@@ -134,7 +135,7 @@
     <script type="text/javascript">
       window.qsSchema = {{ qsSchema|safe }};
       window.questions = {{ questions|safe }};
-      window.datasetContext = {{ datasetContext|safe }};
+      window.datasetContext = {{ datasetContext|dump }};
     </script>
   </div>
 </section>
@@ -201,6 +202,7 @@
   </div>
 </section>
 </form>
+{% endif %}
 
 <script src="/scripts/compiled/entry.js" type="text/javascript"></script>
 

--- a/tests/question_form.js
+++ b/tests/question_form.js
@@ -220,7 +220,7 @@ describe('<QuestionForm />', () => {
   describe('QuestionFields have correct initial state', function() {
     beforeEach(function () {
       this.wrapper =
-        mount(<QuestionForm questions={questions} qsSchema={qsSchema} context={{}} context={{}} />);
+        mount(<QuestionForm questions={questions} qsSchema={qsSchema} context={{}} />);
     });
 
     it('renders list of Questions', function() {


### PR DESCRIPTION
Populate the `datasetContext` object with a `datasetName` and `updateEvery` key used in the 'submit' action, and template render, to make the entry form more dataset-specific. This PR allows the question text and description to be pre-rendered with nunjucks against the `datasetContext` before rendering the template in the normal way. This allows the React component to have access to the fully rendered question text.

This PR fulfils the requirement in #753: A context object accessible from the QuestionSet. e.g. The context object could be the associated Dataset, allowing access to dataset-specific properties within Questions, such as time intervals.