### PR TITLE
Pending submissions are public (and fields readonly)

### DIFF
--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -290,15 +290,17 @@ var pending = function(req, res) {
         reviewComments: entry.reviewComments
       };
 
+      let reviewersData = {place: place, dataset: dataset};
+      let reviewers = utils.getReviewers(req, reviewersData);
+      let canReview = utils.canReview(reviewers, req.user);
       let initialHTML = renderToString(<EntryForm questions={questions}
                                                   qsSchema={qsSchema}
                                                   context={datasetContext}
                                                   answers={formData}
                                                   place={entry.place}
                                                   dataset={entry.dataset}
-                                                  isReview={true} />);
-      let reviewersData = {place: place, dataset: dataset};
-      let reviewers = utils.getReviewers(req, reviewersData);
+                                                  isReview={true}
+                                                  canReview={canReview} />);
       let entryStatus = 'pending';
       if (entry.isCurrent) {
         entryStatus = 'accepted';
@@ -321,7 +323,7 @@ var pending = function(req, res) {
         isReview: true,
         entryStatus: entryStatus,
         entry: entry,
-        canReview: utils.canReview(reviewers, req.user),
+        canReview: canReview,
         reviewClosed: entry.reviewResult ||
           (entry.year !== req.app.get('year'))
       });

--- a/census/ui_app/EntryForm.jsx
+++ b/census/ui_app/EntryForm.jsx
@@ -129,6 +129,9 @@ const EntryForm = React.createClass({
   },
 
   render() {
+    let readonly = (this.props.isReview && !this.props.canReview);
+    let readOnlyOpts = {};
+    if (readonly) readOnlyOpts.readOnly = 'readonly';
     return (<div>
 <section>
   <div className="container">
@@ -141,6 +144,7 @@ const EntryForm = React.createClass({
                   qsSchema={this.yourKnowledgeQSSchema}
                   questions={this.yourKnowledgeQuestions}
                   answers={this.props.answers.aboutYouAnswers}
+                  readonly={readonly}
                   labelPrefix={'A'}
                   ref={'yourKnowledgeQuestions'} />
   </div>
@@ -156,6 +160,7 @@ const EntryForm = React.createClass({
                   qsSchema={this.props.qsSchema}
                   questions={this.props.questions}
                   answers={this.props.answers.answers}
+                  readonly={readonly}
                   labelPrefix={'B'}
                   ref={'questions'} />
   </div>
@@ -177,7 +182,8 @@ const EntryForm = React.createClass({
           <div className="answer-wrapper">
             <div className="answer">
               <textarea name="details" rows="5"
-                        defaultValue={this.props.answers.details}></textarea>
+                        defaultValue={this.props.answers.details}
+                        {...readOnlyOpts}></textarea>
             </div>
           </div>
         </div>
@@ -204,14 +210,16 @@ const EntryForm = React.createClass({
               <input type="radio" name="anonymous"
                      id="anonymousNo"
                      value="No"
-                     defaultChecked={this.props.answers.anonymous === 'No'} />
+                     defaultChecked={this.props.answers.anonymous === 'No'}
+                     {...readOnlyOpts} />
               <label htmlFor="anonymousNo">
                 <span>No</span>
               </label>
               <input type="radio" name="anonymous"
                      id="anonymousYes"
                      value="Yes"
-                     defaultChecked={this.props.answers.anonymous === 'Yes'} />
+                     defaultChecked={this.props.answers.anonymous === 'Yes'}
+                     {...readOnlyOpts} />
               <label htmlFor="anonymousYes">
                 <span>Yes</span>
               </label>
@@ -223,6 +231,7 @@ const EntryForm = React.createClass({
     </div>
 
     <helpers.SubmitActions isReview={this.props.isReview}
+                           canReview={this.props.canReview}
                            onSubmitHandler={this.onSubmitHandler}
                            reviewComments={this.props.answers.reviewComments} />
 

--- a/census/ui_app/HelperFields.jsx
+++ b/census/ui_app/HelperFields.jsx
@@ -17,7 +17,7 @@ const CurrentEntry = props => {
 };
 
 const SubmitActions = props => {
-  if (props.isReview) {
+  if (props.isReview && props.canReview) {
     return (<div>
     <div className="text question">
       <div className="main">
@@ -66,6 +66,8 @@ const SubmitActions = props => {
       <div className="comments"></div>
     </div>
     </div>);
+  } else if (props.isReview && !props.canReview) {
+    return null;
   } else {
     return (<div className="submit continuation question">
       <div className="main">
@@ -113,6 +115,8 @@ const QuestionInstructions = props => {
 
 const QuestionComments = React.createClass({
   render() {
+    let readOnlyOpts = {};
+    if (this.props.readonly) readOnlyOpts.readOnly = 'readonly';
     return (<div className="comments">
       <label htmlFor={this.props.id + '_comment'}>Comments</label>
       <textarea placeholder={this.props.placeholder || 'Add comments' }
@@ -121,7 +125,8 @@ const QuestionComments = React.createClass({
                 name={this.props.id + '_comment'}
                 value={this.props.commentValue}
                 onChange={this.handler}
-                disabled={this.props.disabled}></textarea>
+                disabled={this.props.disabled}
+                {...readOnlyOpts}></textarea>
     </div>);
   },
 

--- a/census/ui_app/QuestionFields.jsx
+++ b/census/ui_app/QuestionFields.jsx
@@ -38,6 +38,8 @@ const baseQuestionField = QuestionField => {
 
 let QuestionFieldText = React.createClass({
   render() {
+    let readOnlyOpts = {};
+    if (this.props.readonly) readOnlyOpts.readOnly = 'readonly';
     return (<div className={'text question ' + this.props.getClassValues()}>
       <div className="main">
         <div>
@@ -55,7 +57,8 @@ let QuestionFieldText = React.createClass({
                      value={this.props.value}
                      name={this.props.id}
                      onChange={this.handler}
-                     disabled={!this.props.visibleProps.enabled} />
+                     disabled={!this.props.visibleProps.enabled}
+                     {...readOnlyOpts} />
             </div>
           </div>
         </div>
@@ -64,7 +67,8 @@ let QuestionFieldText = React.createClass({
                                 placeholder={this.props.placeholder}
                                 commentValue={this.props.commentValue}
                                 onCommentChange={this.props.onCommentChange}
-                                disabled={!this.props.visibleProps.enabled} />
+                                disabled={!this.props.visibleProps.enabled}
+                                readonly={this.props.readonly} />
     </div>);
   },
 
@@ -76,6 +80,8 @@ QuestionFieldText = baseQuestionField(QuestionFieldText);
 
 let QuestionFieldYesNo = React.createClass({
   render() {
+    let readOnlyOpts = {};
+    if (this.props.readonly) readOnlyOpts.readOnly = 'readonly';
     return (<div className={'yes-no question ' + this.props.getClassValues()}>
       <div className="main">
         <div>
@@ -95,7 +101,8 @@ let QuestionFieldYesNo = React.createClass({
                      value="No"
                      checked={(this.props.value === 'No')}
                      disabled={!this.props.visibleProps.enabled}
-                     onChange={this.handler} />
+                     onChange={this.handler}
+                     {...readOnlyOpts} />
               <label htmlFor={this.props.id + '1'}>
                 <span>No</span>
               </label>
@@ -105,7 +112,8 @@ let QuestionFieldYesNo = React.createClass({
                      value="Yes"
                      checked={(this.props.value === 'Yes')}
                      disabled={!this.props.visibleProps.enabled}
-                     onChange={this.handler} />
+                     onChange={this.handler}
+                     {...readOnlyOpts} />
               <label htmlFor={this.props.id + '2'}>
                 <span>Yes</span>
               </label>
@@ -117,17 +125,22 @@ let QuestionFieldYesNo = React.createClass({
                                 placeholder={this.props.placeholder}
                                 commentValue={this.props.commentValue}
                                 onCommentChange={this.props.onCommentChange}
-                                disabled={!this.props.visibleProps.enabled} />
+                                disabled={!this.props.visibleProps.enabled}
+                                readonly={this.props.readonly} />
     </div>);
   },
 
   handler(e) {
-    this.props.onChange(this, e.target.value);
+    if (!this.props.readonly) {
+      this.props.onChange(this, e.target.value);
+    }
   }
 });
 QuestionFieldYesNo = baseQuestionField(QuestionFieldYesNo);
 
 const QuestionFieldLikertOption = props => {
+  let readOnlyOpts = {};
+  if (props.readonly) readOnlyOpts.readOnly = 'readonly';
   return (
     <span>
       <input type="radio"
@@ -136,7 +149,8 @@ const QuestionFieldLikertOption = props => {
              value={props.value}
              onChange={props.handler}
              checked={props.checked}
-             disabled={props.disabled} />
+             disabled={props.disabled}
+             {...readOnlyOpts} />
       <label htmlFor={props.id + props.value}>
         <span>{props.value}</span> <em className="description">{props.description}</em>
       </label>
@@ -154,7 +168,8 @@ let QuestionFieldLikert = React.createClass({
                                         key={this.props.id + option.value}
                                         handler={this.handler}
                                         checked={this.props.value === option.value}
-                                        disabled={!this.props.visibleProps.enabled} />;
+                                        disabled={!this.props.visibleProps.enabled}
+                                        readonly={this.props.readonly} />;
     });
     return (<div className={'scale question ' + this.props.getClassValues()}>
       <div className="main">
@@ -178,17 +193,25 @@ let QuestionFieldLikert = React.createClass({
                                 placeholder={this.props.placeholder}
                                 commentValue={this.props.commentValue}
                                 onCommentChange={this.props.onCommentChange}
-                                disabled={!this.props.visibleProps.enabled} />
+                                disabled={!this.props.visibleProps.enabled}
+                                readonly={this.props.readonly} />
     </div>);
   },
 
   handler(e) {
-    this.props.onChange(this, e.target.value);
+    if (!this.props.readonly) {
+      this.props.onChange(this, e.target.value);
+    }
   }
 });
 QuestionFieldLikert = baseQuestionField(QuestionFieldLikert);
 
 const QuestionFieldSourceLine = props => {
+  let commonOpts = {
+    onChange: props.onChange,
+    disabled: props.disabled
+  };
+  if (props.readonly) commonOpts.readOnly = 'readonly';
   return (
     <ul>
       <li>
@@ -199,8 +222,7 @@ const QuestionFieldSourceLine = props => {
                data-key={'urlValue'}
                placeholder="http://"
                value={props.urlValue}
-               onChange={props.onChange}
-               disabled={props.disabled} />
+               {...commonOpts} />
       </li>
       <li>
         <label htmlFor={props.id + '_desc'}>Source description</label>
@@ -209,8 +231,7 @@ const QuestionFieldSourceLine = props => {
                type="text"
                data-key={'descValue'}
                value={props.descValue}
-               onChange={props.onChange}
-               disabled={props.disabled} />
+               {...commonOpts} />
       </li>
     </ul>
   );
@@ -246,6 +267,7 @@ let QuestionFieldSource = React.createClass({
                                           descValue={sourceValue.descValue}
                                           onChange={this.handler.bind(this, i)}
                                           disabled={!this.props.visibleProps.enabled}
+                                          readonly={this.props.readonly}
                                            />;
       sourceLines.push(node);
     }
@@ -272,7 +294,8 @@ let QuestionFieldSource = React.createClass({
                         commentValue={this.props.commentValue}
                         onCommentChange={this.props.onCommentChange}
                         disabled={!this.props.visibleProps.enabled}
-                        disabled={!this.props.visibleProps.enabled} />
+                        disabled={!this.props.visibleProps.enabled}
+                        readonly={this.props.readonly} />
     </div>);
   },
 
@@ -287,6 +310,8 @@ let QuestionFieldSource = React.createClass({
 QuestionFieldSource = baseQuestionField(QuestionFieldSource);
 
 const QuestionFieldMultipleChoiceOption = props => {
+  let readOnlyOpts = {};
+  if (props.readonly) readOnlyOpts.readOnly = 'readonly';
   return (
     <li>
       <input type="checkbox"
@@ -295,7 +320,8 @@ const QuestionFieldMultipleChoiceOption = props => {
              value="1"
              checked={props.checked}
              onChange={props.handler}
-             disabled={props.disabled} />
+             disabled={props.disabled}
+             {...readOnlyOpts} />
       <label htmlFor={props.id}>
         <span className="letter">{props.label}</span> <span className="description">{props.children.toString()}</span>
       </label>
@@ -305,6 +331,8 @@ const QuestionFieldMultipleChoiceOption = props => {
 
 const QuestionFieldMultipleChoiceOther = props => {
   if (props.includeOther) {
+    let readOnlyOpts = {};
+    if (props.readonly) readOnlyOpts.readOnly = 'readonly';
     return (
       <div className="other text sub">
         <h3>Other</h3>
@@ -312,7 +340,8 @@ const QuestionFieldMultipleChoiceOther = props => {
           <input name={props.id}
                  value={props.value}
                  type="text"
-                 disabled={props.disabled} />
+                 disabled={props.disabled}
+                 {...readOnlyOpts} />
         </div>
       </div>
     );
@@ -363,7 +392,8 @@ let QuestionFieldMultipleChoice = React.createClass({
                                                 checked={option.checked}
                                                 label={label}
                                                 handler={this.handler.bind(this, i)}
-                                                disabled={!this.props.visibleProps.enabled}>
+                                                disabled={!this.props.visibleProps.enabled}
+                                                readonly={this.props.readonly}>
                 {option.description}
               </QuestionFieldMultipleChoiceOption>;
     });
@@ -389,7 +419,8 @@ let QuestionFieldMultipleChoice = React.createClass({
             </div>
             <QuestionFieldMultipleChoiceOther includeOther={this.props.config.includeOther}
                                               id={this.props.id + '_other'}
-                                              disabled={!this.props.visibleProps.enabled} />
+                                              disabled={!this.props.visibleProps.enabled}
+                                              readonly={this.props.readonly} />
           </div>
         </div>
       </div>
@@ -397,7 +428,8 @@ let QuestionFieldMultipleChoice = React.createClass({
                                 placeholder={this.props.placeholder}
                                 commentValue={this.props.commentValue}
                                 onCommentChange={this.props.onCommentChange}
-                                disabled={!this.props.visibleProps.enabled} />
+                                disabled={!this.props.visibleProps.enabled}
+                                readonly={this.props.readonly} />
     </div>);
   },
 
@@ -410,9 +442,11 @@ let QuestionFieldMultipleChoice = React.createClass({
   },
 
   handler(i, e) {
-    let newOptionValues = this.optionValues;
-    newOptionValues[i].checked = e.target.checked;
-    this.props.onChange(this, newOptionValues);
+    if (!this.props.readonly) {
+      let newOptionValues = this.optionValues;
+      newOptionValues[i].checked = e.target.checked;
+      this.props.onChange(this, newOptionValues);
+    }
   }
 });
 QuestionFieldMultipleChoice = baseQuestionField(QuestionFieldMultipleChoice);

--- a/census/ui_app/QuestionForm.jsx
+++ b/census/ui_app/QuestionForm.jsx
@@ -177,7 +177,8 @@ const QuestionForm = React.createClass({
                         config={
                           this.getValueForId(q.id, 'config')
                         }
-                        context={this.props.context}>
+                        context={this.props.context}
+                        readonly={this.props.readonly || false}>
           {this.getValueForId(q.id, 'text')}
         </ComponentClass>
       );

--- a/census/ui_app/entry.jsx
+++ b/census/ui_app/entry.jsx
@@ -7,6 +7,7 @@ let questions = window.questions;
 let datasetContext = window.datasetContext;
 let answers = window.formData;
 let isReview = window.isReview;
+let canReview = window.canReview || false;
 
 // Main QuestionSet, section B.
 render(<EntryForm questions={questions}
@@ -15,5 +16,6 @@ render(<EntryForm questions={questions}
                   answers={answers}
                   place={answers.place}
                   dataset={answers.dataset}
-                  isReview={isReview} />,
+                  isReview={isReview}
+                  canReview={canReview} />,
        document.getElementById('entry_form'));

--- a/census/views/create.html
+++ b/census/views/create.html
@@ -104,7 +104,7 @@
 </div>
 {% endif %}
 
-{% if datasetContext|length and (not isReview or canReview) %}
+{% if datasetContext|length %}
 {% if submitInstructions %}
 <div class="alert alert-info alert-dismissible" role="alert">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -140,6 +140,7 @@
   window.datasetContext = {{ datasetContext|dump }};
   window.formData = {{ formData|dump }};
   window.isReview = {{ isReview }};
+  window.canReview = {{ canReview or false}};
 </script>
 <script src="/scripts/compiled/entry.js" type="text/javascript"></script>
 {% endif %}


### PR DESCRIPTION
The React entry form for pending submissions will now render for non-reviewers, with form fields set to readonly and submit controls removed. This allows the general user to see proposed submissions.

Readonly is set when the entry `isReview=true` but the user `canReview=false`. Fixes #834.