### PR TITLE
Load validation rules from Questions spreadsheet

### DIFF
--- a/census/ui_app/QuestionFields.jsx
+++ b/census/ui_app/QuestionFields.jsx
@@ -70,7 +70,8 @@ const baseQuestionField = QuestionField => {
         let validationErrors = [];
         this.isValid = true;
         _.each(validationRules, ruleName => {
-          if (!validators[ruleName].rule(value)) {
+          if (_.has(validators, ruleName) &&
+              !validators[ruleName].rule(value)) {
             // This value is invalid for the rule, so append the error message
             // and set isValid to false.
             validationErrors.push(validators[ruleName].message);

--- a/census/ui_app/QuestionFields.jsx
+++ b/census/ui_app/QuestionFields.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import * as helpers from './HelperFields.jsx';
-import validator from 'validator';
+import validators from './validators.js';
 
 // A base Higher-Order Component providing common behaviour for all Question
 // Fields.
@@ -42,15 +42,10 @@ const baseQuestionField = QuestionField => {
       this.isValid = true;
       // A list of rules to apply for this Question.
       this.validationRules = this.props.validationRules || [];
-      // An object containing available validators.
-      this.validators = {
-        required: {
-          rule: value => {
-            return !validator.isEmpty(value.toString());
-          },
-          message: 'Question is required'
-        }
-      };
+      if (_.has(this.props, 'config.validation')) {
+        this.validationRules = _.union(this.validationRules,
+                                       this.props.config.validation);
+      }
       this.setState({validationErrors: []});
     },
 
@@ -75,10 +70,10 @@ const baseQuestionField = QuestionField => {
         let validationErrors = [];
         this.isValid = true;
         _.each(validationRules, ruleName => {
-          if (!this.validators[ruleName].rule(value)) {
+          if (!validators[ruleName].rule(value)) {
             // This value is invalid for the rule, so append the error message
             // and set isValid to false.
-            validationErrors.push(this.validators[ruleName].message);
+            validationErrors.push(validators[ruleName].message);
             this.isValid = false;
           }
         });

--- a/census/ui_app/validators.js
+++ b/census/ui_app/validators.js
@@ -1,0 +1,18 @@
+import validator from 'validator';
+
+let validators = {
+  isURL: {
+    rule: value => {
+      return validator.isURL(value);
+    },
+    message: 'Must be a valid URL'
+  },
+  required: {
+    rule: value => {
+      return !validator.isEmpty(value.toString());
+    },
+    message: 'Question is required'
+  }
+};
+
+module.exports = validators;

--- a/census/ui_app/validators.js
+++ b/census/ui_app/validators.js
@@ -12,6 +12,17 @@ let validators = {
       return !validator.isEmpty(value.toString());
     },
     message: 'Question is required'
+  },
+  sourceIsURL: {
+    rule: value => {
+      for (let i = 0; i < value.length; i++) {
+        if (!validator.isURL(value[i].urlValue)) {
+          return false;
+        }
+      }
+      return true;
+    },
+    message: 'Each source URL must be a valid URL'
   }
 };
 


### PR DESCRIPTION
Validation rules for a question can be specified within the `question.config` object, e.g.:

```js
{
  "validation": [
    "isURL"
  ]
}
```

This PR fulfils the 'Add validationRule loading from spreadsheet' part of #829 and closes #838.