### PR TITLE
Add link to Discourse forum for submissions

### DIFF
--- a/census/config/index.js
+++ b/census/config/index.js
@@ -54,6 +54,8 @@ nconf.defaults({
 
   'disqus_shortname': process.env.DISQUS_SHORTNAME || 'opendatacensus',
   'discussion_forum': process.env.DISCUSSION_FORUM || '', // forum URL
+  'submission_discourse_hostname': process.env.SUBMISSION_DISCOURSE_HOSTNAME ||
+    'discuss.okfn.org',
   'about_page': '<h1>To set content for this page update your ' +
     'configuration file</h1>',
   'contribute_page': '<h1>To set content for this page update your ' +

--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -4,6 +4,8 @@ const _ = require('lodash');
 const marked = require('marked');
 const config = require('../config');
 const uuid = require('node-uuid');
+const url = require('url');
+const querystring = require('querystring');
 const utils = require('./utils');
 const util = require('util');
 const modelUtils = require('../models').utils;
@@ -219,6 +221,39 @@ var submit = function(req, res) {
   });
 };
 
+let _getDiscussionURL = function(req, dataset, place) {
+  /*
+    If `submission_discussion_url` is defined in settings and it is in the
+    format: https://discuss.okfn.org/c/<topic>/<subtopic>, return a new topic
+    url with a prepopulated topic for place and dataset. Otherwise, return the
+    original `submission_discussion_url` without modification. If
+    `submission_discussion_url` is undefined return an empty string.
+  */
+  let submissionDiscussionURL =
+    _.get(req.params.site.settings, 'submission_discussion_url', '');
+  let parsedURL = url.parse(submissionDiscussionURL);
+  // URL is a discourse link
+  if (parsedURL.hostname === 'discuss.okfn.org') {
+    let splitPathName = _.trimLeft(parsedURL.pathname, '/').split('/');
+    // URL is a category link
+    if (splitPathName[0] === 'c') {
+      // Create a new topic link
+      let newTopicURL = url.parse('');
+      newTopicURL.protocol = parsedURL.protocol;
+      newTopicURL.host = parsedURL.host;
+      newTopicURL.pathname = 'new-topic';
+      newTopicURL.search = querystring.stringify({
+        title: util.format('Entry for %s / %s', dataset, place),
+        body: util.format('This is a discussion about the submission for [%s / %s](%s).',
+                          dataset, place, req.res.locals.current_url),
+        category: _.rest(splitPathName).join('/').replace(/-/g, ' ')
+      });
+      submissionDiscussionURL = url.format(newTopicURL);
+    }
+  }
+  return submissionDiscussionURL;
+};
+
 var pending = function(req, res) {
   let entryQueryParams = {
     where: {id: req.params.id},
@@ -258,7 +293,7 @@ var pending = function(req, res) {
         updateEvery: dataset.updateevery
       });
     }
-
+    let submissionDiscussionURL = _getDiscussionURL(req, dataset.name, place.name);
     Promise.join(qsSchemaPromise, questionsPromise, (qsSchema, questions) => {
       if (qsSchema === undefined) qsSchema = [];
       let match = {place: place.id, dataset: dataset.id};
@@ -300,7 +335,8 @@ var pending = function(req, res) {
                                                   place={entry.place}
                                                   dataset={entry.dataset}
                                                   isReview={true}
-                                                  canReview={canReview} />);
+                                                  canReview={canReview}
+                                                  submissionDiscussionURL={submissionDiscussionURL} />);
       let entryStatus = 'pending';
       if (entry.isCurrent) {
         entryStatus = 'accepted';
@@ -319,6 +355,7 @@ var pending = function(req, res) {
         initialRenderedEntry: initialHTML,
         breadcrumbTitle: 'Review a Submission',
         submitInstructions: config.get('review_page'),
+        submissionDiscussionURL: submissionDiscussionURL,
         errors: _.get(data, 'errors'),
         isReview: true,
         entryStatus: entryStatus,

--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -233,7 +233,7 @@ let _getDiscussionURL = function(req, dataset, place) {
     _.get(req.params.site.settings, 'submission_discussion_url', '');
   let parsedURL = url.parse(submissionDiscussionURL);
   // URL is a discourse link
-  if (parsedURL.hostname === 'discuss.okfn.org') {
+  if (parsedURL.hostname === config.get('submission_discourse_hostname', '')) {
     let splitPathName = _.trimLeft(parsedURL.pathname, '/').split('/');
     // URL is a category link
     if (splitPathName[0] === 'c') {

--- a/census/ui_app/EntryForm.jsx
+++ b/census/ui_app/EntryForm.jsx
@@ -252,6 +252,8 @@ const EntryForm = React.createClass({
                            onSubmitHandler={this.onSubmitHandler}
                            reviewComments={this.props.answers.reviewComments} />
 
+    <helpers.DiscussionLink url={this.props.submissionDiscussionURL} isReview={this.props.isReview} />
+
   </div>
 </footer>
 </div>);

--- a/census/ui_app/HelperFields.jsx
+++ b/census/ui_app/HelperFields.jsx
@@ -1,6 +1,22 @@
 import _ from 'lodash';
 import React from 'react';
 
+const DiscussionLink = props => {
+  if (props.isReview && props.url) {
+    return (
+    <div className="submit continuation question">
+      <div className="main">
+        <div>
+          <div className="instructions"></div>
+          <p>Do you want to discuss this submission? Start a <a target="_blank" href={props.url}>new topic</a> on the forum!</p>
+        </div>
+      </div>
+    </div>
+    );
+  }
+  return null;
+};
+
 const QuestionErrors = props => {
   if (props.errors && props.errors.length) {
     let errorItems = _.map(props.errors, (err, i) => <li key={i}>{err}</li>);
@@ -156,6 +172,7 @@ const QuestionHeader = props => {
 };
 
 export {
+  DiscussionLink,
   QuestionErrors,
   QuestionInstructions,
   QuestionComments,

--- a/census/ui_app/entry.jsx
+++ b/census/ui_app/entry.jsx
@@ -8,6 +8,7 @@ let datasetContext = window.datasetContext;
 let answers = window.formData;
 let isReview = window.isReview;
 let canReview = window.canReview || false;
+let submissionDiscussionURL = window.submissionDiscussionURL;
 
 // Main QuestionSet, section B.
 render(<EntryForm questions={questions}
@@ -17,5 +18,6 @@ render(<EntryForm questions={questions}
                   place={answers.place}
                   dataset={answers.dataset}
                   isReview={isReview}
-                  canReview={canReview} />,
+                  canReview={canReview}
+                  submissionDiscussionURL={submissionDiscussionURL} />,
        document.getElementById('entry_form'));

--- a/census/views/create.html
+++ b/census/views/create.html
@@ -140,7 +140,8 @@
   window.datasetContext = {{ datasetContext|dump }};
   window.formData = {{ formData|dump }};
   window.isReview = {{ isReview }};
-  window.canReview = {{ canReview or false}};
+  window.canReview = {{ canReview or false }};
+  window.submissionDiscussionURL = "{{ submissionDiscussionURL or '' }}";
 </script>
 <script src="/scripts/compiled/entry.js" type="text/javascript"></script>
 {% endif %}

--- a/docs/site-admins/index.md
+++ b/docs/site-admins/index.md
@@ -299,6 +299,10 @@ Supply a google analytics key to use on the site
 Custom support url linked from the top-level 'Support' navigation item. If
 absent, the `discussionForum` global settings will be used instead.
 
+### submission_discussion_url
+
+A URL to a forum where users can discuss pending submissions. This URL will be linked from the bottom of the pending submission page. If the URL links to the discuss.okfn.org Discourse instance (in the format `http://discuss.okfn.org/c/<topic>/<subtopic>`), the link will be formatted to automatically create a new topic, pre-populated with a title, category, and body text linking back to the submission.
+
 [template-config]: https://docs.google.com/spreadsheets/d/1ziJAlV4F02467oAmH1CDUdWBYdRp7LlVZgDVUuJU-l8/edit#gid=2
 [template-questions]: https://docs.google.com/spreadsheets/d/1nwmk8uJEK-4K6-5SdBgoLUlUos-BhfYRgjS74YkhDGc/edit#gid=3
 [discussion-forum]: https://discuss.okfn.org/c/open-data-index


### PR DESCRIPTION
To allow users to discuss pending submissions, we want to link to the appropriate discussion forum from the submission page. A forum url can be defined in the site config under the `submission_discussion_url` key. If it's a link to the okfn.org Discourse instance in the format `http://discuss.okfn.org/c/<topic>/<subtopic>`, the link will be formatted to automatically create a new topic, pre-populated with a title, category, and body text linking back to the submission.

New link:
<img width="631" alt="new_topic" src="https://cloud.githubusercontent.com/assets/3993/20763222/017aa0f0-b721-11e6-9e83-7358d3127c63.png">

Pre-populated forum post:
<img width="1027" alt="new_topic_prepop" src="https://cloud.githubusercontent.com/assets/3993/20763242/0e2a8da6-b721-11e6-804b-04c6360d49b4.png">

Closes #848.
