### PR TITLE
API actions for updated Survey strategy

### DIFF
--- a/census/controllers/api.js
+++ b/census/controllers/api.js
@@ -39,6 +39,7 @@ let questions = function(req, res) {
   const dataOptions = _.merge(
     modelUtils.getDataOptions(req),
     {
+      scoredQuestionsOnly: false,
       cascade: false,
       with: {Place: false, Entry: false, Dataset: false}
     }

--- a/census/controllers/api.js
+++ b/census/controllers/api.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var csv = require('csv');
-var _ = require('lodash');
-var moment = require('moment');
-var utils = require('./utils');
-var modelUtils = require('../models').utils;
+const csv = require('csv');
+const _ = require('lodash');
+const moment = require('moment');
+const utils = require('./utils');
+const modelUtils = require('../models').utils;
 
-var outputItemsAsJson = function(response, items, mapper) {
+let outputItemsAsJson = function(response, items, mapper) {
   if (_.isFunction(mapper)) {
     items = _.map(items, mapper);
   }
   response.json({count: items.length, results: items});
 };
 
-var outputItemsAsCsv = function(response, items, mapper, columns) {
-  var options = {
+let outputItemsAsCsv = function(response, items, mapper, columns) {
+  let options = {
     delimiter: ',',
     quote: '"',
     quoted: true,
@@ -27,18 +27,16 @@ var outputItemsAsCsv = function(response, items, mapper, columns) {
   if (_.isFunction(mapper)) {
     items = _.map(items, mapper);
   }
-  var stringify = csv.stringify(items, options);
+  let stringify = csv.stringify(items, options);
   response.header('Content-Type', 'text/csv');
   stringify.pipe(response);
 };
 
-var questions = function(req, res) {
-
+let questions = function(req, res) {
   // Get request params
-  var format = req.params.format;
-
+  const format = req.params.format;
   // Initial data options
-  var dataOptions = _.merge(
+  const dataOptions = _.merge(
     modelUtils.getDataOptions(req),
     {
       cascade: false,
@@ -48,8 +46,7 @@ var questions = function(req, res) {
 
   // Make request for data, return it
   modelUtils.getData(dataOptions).then(function(data) {
-
-    var columns = [
+    const columns = [
       'id',
       'site',
       'question',
@@ -59,11 +56,11 @@ var questions = function(req, res) {
       'score',
       'order',
       'icon',
-      'dependants',
+      'dependants'
     ];
-    var results = data.questions;
-    var mapper = function(item) {
-      var result = {};
+    const results = data.questions;
+    let mapper = function(item) {
+      let result = {};
       _.each(columns, function(name) {
         result[name] = item[name];
       });
@@ -84,32 +81,28 @@ var questions = function(req, res) {
         break;
       }
     }
-
   }).catch(console.trace.bind(console));
-
 };
 
-var datasets = function(req, res, next) {
-
+let datasets = function(req, res, next) {
   // Get request params
-  var report = req.params.report;
-  var strategy = req.params.strategy;
-  var format = req.params.format;
+  const report = req.params.report;
+  const strategy = req.params.strategy;
+  const format = req.params.format;
 
   // Report can be only `score`
-  var isScore = false;
+  let isScore = false;
   if (report === 'score') {
-    var isScore = true;
+    isScore = true;
   } else if (report) {
     return res.sendStatus(404);
   }
 
   // Initial data options
-  var dataOptions = _.merge(modelUtils.getDataOptions(req), {
-      cascade: false,
-      with: {Place: false, Entry: isScore, Question: isScore}
-    }
-  );
+  let dataOptions = _.merge(modelUtils.getDataOptions(req), {
+    cascade: false,
+    with: {Place: false, Entry: isScore, Question: isScore}
+  });
 
   // Strategy can be only `cascade`
   if (strategy === 'cascade') {
@@ -120,26 +113,25 @@ var datasets = function(req, res, next) {
 
   // Make request for data, return it
   modelUtils.getData(dataOptions).then(function(data) {
-
-    var columns = [
+    let columns = [
       'id',
       'site',
       'name',
       'description',
       'category',
       'icon',
-      'order',
+      'order'
     ];
     if (isScore) {
       columns = columns.concat([
         'rank',
         'score',
-        'relativeScore',
+        'relativeScore'
       ]);
     }
-    var results = data.datasets;
-    var mapper = function(item) {
-      var result = {};
+    const results = data.datasets;
+    let mapper = function(item) {
+      let result = {};
       item.score = item.computedScore;
       item.relativeScore = item.computedRelativeScore;
       _.each(columns, function(name) {
@@ -162,32 +154,28 @@ var datasets = function(req, res, next) {
         break;
       }
     }
-
   }).catch(console.trace.bind(console));
-
 };
 
-var places = function(req, res, next) {
-
+let places = function(req, res, next) {
   // Get request params
-  var report = req.params.report;
-  var strategy = req.params.strategy;
-  var format = req.params.format;
+  const report = req.params.report;
+  const strategy = req.params.strategy;
+  const format = req.params.format;
 
   // Report can be only `score`
-  var isScore = false;
+  let isScore = false;
   if (report === 'score') {
-    var isScore = true;
+    isScore = true;
   } else if (report) {
     return res.sendStatus(404);
   }
 
   // Initial data options
-  var dataOptions = _.merge(modelUtils.getDataOptions(req), {
-      cascade: false,
-      with: {Dataset: false, Entry: isScore, Question: isScore}
-    }
-  );
+  let dataOptions = _.merge(modelUtils.getDataOptions(req), {
+    cascade: false,
+    with: {Dataset: false, Entry: isScore, Question: isScore}
+  });
 
   // Strategy can be only `cascade`
   if (strategy === 'cascade') {
@@ -198,31 +186,30 @@ var places = function(req, res, next) {
 
   // Make request for data, return it
   modelUtils.getData(dataOptions).then(function(data) {
-
-    var columns = [
+    let columns = [
       'id',
       'site',
       'name',
       'slug',
       'region',
-      'continent',
+      'continent'
     ];
     if (isScore) {
       columns = columns.concat([
         'rank',
         'score',
-        'relativeScore',
+        'relativeScore'
       ]);
     }
-    var results = data.places;
-    var mapper = function(item) {
-       var result = {};
-       item.score = item.computedScore;
-       item.relativeScore = item.computedRelativeScore;
-       _.each(columns, function(name) {
-         result[name] = item[name];
-       });
-       return result;
+    const results = data.places;
+    let mapper = function(item) {
+      let result = {};
+      item.score = item.computedScore;
+      item.relativeScore = item.computedRelativeScore;
+      _.each(columns, function(name) {
+        result[name] = item[name];
+      });
+      return result;
     };
 
     switch (format) {
@@ -239,24 +226,20 @@ var places = function(req, res, next) {
         break;
       }
     }
-
   }).catch(console.trace.bind(console));
-
 };
 
-var entries = function(req, res, next) {
-
+let entries = function(req, res, next) {
   // Get request params
-  var format = req.params.format;
-  var strategy = req.params.strategy;
+  const format = req.params.format;
+  const strategy = req.params.strategy;
 
   // Initial data options
-  var dataOptions = _.merge(modelUtils.getDataOptions(req), {
-      cascade: false,
-      scoredQuestionsOnly: false,
-      with: {Dataset: false, Place: false, Question: true}
-    }
-  );
+  let dataOptions = _.merge(modelUtils.getDataOptions(req), {
+    cascade: false,
+    scoredQuestionsOnly: false,
+    with: {Dataset: false, Place: false, Question: true}
+  });
 
   // If year is implicitly set
   if (!!req.params.isYearImplicitlySet) {
@@ -274,92 +257,90 @@ var entries = function(req, res, next) {
 
   // Make request for data, return it
   modelUtils.getData(dataOptions).then(function(data) {
-
-      var results = data.entries;
-      var mapper = function(item) {
-        var answers = utils.ynuAnswers(item.answers || {});
-        return {
-          id: item.id,
-          site: item.site,
-          timestamp: moment(item.createdAt).format('YYYY-MM-DDTHH:mm:ss'),
-          year: item.year,
-          place: item.place,
-          dataset: item.dataset,
-          exists: answers.exists,
-          digital: answers.digital,
-          public: answers.public,
-          online: answers.online,
-          free: answers.free,
-          machinereadable: answers.machinereadable,
-          bulk: answers.bulk,
-          openlicense: answers.openlicense,
-          uptodate: answers.uptodate,
-          url: answers.url,
-          format: answers.format,
-          licenseurl: answers.licenseurl,
-          dateavailable: answers.dateavailable,
-          officialtitle: answers.officialtitle,
-          publisher: answers.publisher,
-          reviewed: item.reviewed ? 'Yes' : 'No',
-          reviewResult: item.reviewResult ? 'Yes' : 'No',
-          reviewComments: item.reviewComments,
-          details: item.details,
-          isCurrent: item.isCurrent ? 'Yes' : 'No',
-          isOpen: item.isOpenForQuestions(data.questions) ? 'Yes' : 'No',
-          submitter: item.Submitter ? item.Submitter.fullName() : '',
-          reviewer: item.Reviewer ? item.Reviewer.fullName() : '',
-          score: item.computedScore
-        };
+    const results = data.entries;
+    let mapper = function(item) {
+      const answers = utils.ynuAnswers(item.answers || {});
+      return {
+        id: item.id,
+        site: item.site,
+        timestamp: moment(item.createdAt).format('YYYY-MM-DDTHH:mm:ss'),
+        year: item.year,
+        place: item.place,
+        dataset: item.dataset,
+        exists: answers.exists,
+        digital: answers.digital,
+        public: answers.public,
+        online: answers.online,
+        free: answers.free,
+        machinereadable: answers.machinereadable,
+        bulk: answers.bulk,
+        openlicense: answers.openlicense,
+        uptodate: answers.uptodate,
+        url: answers.url,
+        format: answers.format,
+        licenseurl: answers.licenseurl,
+        dateavailable: answers.dateavailable,
+        officialtitle: answers.officialtitle,
+        publisher: answers.publisher,
+        reviewed: item.reviewed ? 'Yes' : 'No',
+        reviewResult: item.reviewResult ? 'Yes' : 'No',
+        reviewComments: item.reviewComments,
+        details: item.details,
+        isCurrent: item.isCurrent ? 'Yes' : 'No',
+        isOpen: item.isOpenForQuestions(data.questions) ? 'Yes' : 'No',
+        submitter: item.Submitter ? item.Submitter.fullName() : '',
+        reviewer: item.Reviewer ? item.Reviewer.fullName() : '',
+        score: item.computedScore
       };
+    };
 
-      switch (format) {
-        case 'json': {
-          outputItemsAsJson(res, results, mapper);
-          break;
-        }
-        case 'csv': {
-          var columns = [
-            'id',
-            'site',
-            'timestamp',
-            'year',
-            'place',
-            'dataset',
-            'exists',
-            'digital',
-            'public',
-            'online',
-            'free',
-            'machinereadable',
-            'bulk',
-            'openlicence',
-            'uptodate',
-            'url',
-            'format',
-            'licenseurl',
-            'dateavailable',
-            'officialtitle',
-            'publisher',
-            'reviewed',
-            'reviewResult',
-            'reviewComments',
-            'details',
-            'isCurrent',
-            'isOpen',
-            'submitter',
-            'reviewer',
-            'score',
-          ];
-          outputItemsAsCsv(res, results, mapper, columns);
-          break;
-        }
-        default: {
-          res.sendStatus(404);
-          break;
-        }
+    switch (format) {
+      case 'json': {
+        outputItemsAsJson(res, results, mapper);
+        break;
       }
-    }).catch(console.trace.bind(console));
-
+      case 'csv': {
+        var columns = [
+          'id',
+          'site',
+          'timestamp',
+          'year',
+          'place',
+          'dataset',
+          'exists',
+          'digital',
+          'public',
+          'online',
+          'free',
+          'machinereadable',
+          'bulk',
+          'openlicence',
+          'uptodate',
+          'url',
+          'format',
+          'licenseurl',
+          'dateavailable',
+          'officialtitle',
+          'publisher',
+          'reviewed',
+          'reviewResult',
+          'reviewComments',
+          'details',
+          'isCurrent',
+          'isOpen',
+          'submitter',
+          'reviewer',
+          'score'
+        ];
+        outputItemsAsCsv(res, results, mapper, columns);
+        break;
+      }
+      default: {
+        res.sendStatus(404);
+        break;
+      }
+    }
+  }).catch(console.trace.bind(console));
 };
 
 module.exports = {

--- a/census/controllers/api.js
+++ b/census/controllers/api.js
@@ -3,7 +3,6 @@
 const csv = require('csv');
 const _ = require('lodash');
 const moment = require('moment');
-const utils = require('./utils');
 const modelUtils = require('../models').utils;
 
 let outputItemsAsJson = function(response, items, mapper) {
@@ -262,8 +261,9 @@ let entries = function(req, res, next) {
   // Make request for data, return it
   modelUtils.getData(dataOptions).then(function(data) {
     const results = data.entries;
+    const questions = data.questions;
     let mapper = function(item) {
-      const answers = utils.ynuAnswers(item.answers || {});
+      let answers = item.getSimpleAnswersForQuestions(questions);
       return {
         id: item.id,
         site: item.site,
@@ -271,21 +271,7 @@ let entries = function(req, res, next) {
         year: item.year,
         place: item.place,
         dataset: item.dataset,
-        exists: answers.exists,
-        digital: answers.digital,
-        public: answers.public,
-        online: answers.online,
-        free: answers.free,
-        machinereadable: answers.machinereadable,
-        bulk: answers.bulk,
-        openlicense: answers.openlicense,
-        uptodate: answers.uptodate,
-        url: answers.url,
-        format: answers.format,
-        licenseurl: answers.licenseurl,
-        dateavailable: answers.dateavailable,
-        officialtitle: answers.officialtitle,
-        publisher: answers.publisher,
+        answers: answers,
         reviewed: item.reviewed ? 'Yes' : 'No',
         reviewResult: item.reviewResult ? 'Yes' : 'No',
         reviewComments: item.reviewComments,
@@ -294,7 +280,8 @@ let entries = function(req, res, next) {
         isOpen: item.isOpenForQuestions(data.questions) ? 'Yes' : 'No',
         submitter: item.Submitter ? item.Submitter.fullName() : '',
         reviewer: item.Reviewer ? item.Reviewer.fullName() : '',
-        score: item.computedScore
+        score: item.computedScore,
+        relativeScore: item.computedRelativeScore
       };
     };
 
@@ -311,21 +298,7 @@ let entries = function(req, res, next) {
           'year',
           'place',
           'dataset',
-          'exists',
-          'digital',
-          'public',
-          'online',
-          'free',
-          'machinereadable',
-          'bulk',
-          'openlicence',
-          'uptodate',
-          'url',
-          'format',
-          'licenseurl',
-          'dateavailable',
-          'officialtitle',
-          'publisher',
+          'answers',
           'reviewed',
           'reviewResult',
           'reviewComments',
@@ -334,7 +307,8 @@ let entries = function(req, res, next) {
           'isOpen',
           'submitter',
           'reviewer',
-          'score'
+          'score',
+          'relativeScore'
         ];
         outputItemsAsCsv(res, results, mapper, columns);
         break;

--- a/census/controllers/api.js
+++ b/census/controllers/api.js
@@ -118,6 +118,8 @@ let datasets = function(req, res, next) {
       'site',
       'name',
       'description',
+      'characteristics',
+      'updateevery',
       'category',
       'icon',
       'order'

--- a/census/controllers/api.js
+++ b/census/controllers/api.js
@@ -51,13 +51,14 @@ let questions = function(req, res) {
       'id',
       'site',
       'question',
+      'questionshort',
       'description',
       'type',
       'placeholder',
       'score',
-      'order',
-      'icon',
-      'dependants'
+      'config',
+      'openquestion',
+      'icon'
     ];
     const results = data.questions;
     let mapper = function(item) {

--- a/census/controllers/utils.js
+++ b/census/controllers/utils.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const modelUtils = require('../models/utils');
 const FIELD_SPLITTER = /[\s,]+/;
 const ANONYMOUS_USER_ID = process.env.ANONYMOUS_USER_ID ||
   '0e7c393e-71dd-4368-93a9-fcfff59f9fff';
@@ -233,56 +232,6 @@ var questionMapper = function(data, site) {
   }, data);
 };
 
-var normalizedAnswers = function(answers) {
-  var normed = {};
-  _.each(answers, function(v, k) {
-    if (v === 'true') {
-      normed[k] = true;
-    } else if (v === 'false') {
-      normed[k] = false;
-    } else if (v === 'null') {
-      normed[k] = null;
-    } else {
-      normed[k] = v;
-    }
-  });
-  return normed;
-};
-
-var ynuAnswers = function(answers) {
-  var ynu = {};
-  _.each(answers, function(v, k) {
-    if (v === null) {
-      ynu[k] = 'Unsure';
-    } else if (v === false) {
-      ynu[k] = 'No';
-    } else if (v === true) {
-      ynu[k] = 'Yes';
-    } else {
-      ynu[k] = v;
-    }
-  });
-  return ynu;
-};
-
-var getFormQuestions = function(req, questions) {
-  questions = modelUtils.translateSet(req, questions);
-  _.each(questions, function(q) {
-    if (q.dependants) {
-      _.each(q.dependants, function(d, i, l) {
-        var match = _.find(questions, function(o) {
-          return o.id === d;
-        });
-        l[i] = match;
-        questions = _.reject(questions, function(o) {
-          return o.id === match.id;
-        });
-      });
-    }
-  });
-  return _.sortByOrder(questions, 'order', 'asc');
-};
-
 var getCurrentState = function(data, match, year) {
   /*
     Return an object containing the state of submissions for a given
@@ -349,9 +298,6 @@ module.exports = {
   placeMapper: placeMapper,
   datasetMapper: datasetMapper,
   questionMapper: questionMapper,
-  normalizedAnswers: normalizedAnswers,
-  ynuAnswers: ynuAnswers,
-  getFormQuestions: getFormQuestions,
   getCurrentState: getCurrentState,
   getReviewers: getReviewers,
   canReview: canReview,

--- a/census/models/entry.js
+++ b/census/models/entry.js
@@ -99,9 +99,41 @@ module.exports = function(sequelize, DataTypes) {
       }
     ],
     instanceMethods: {
+      getAnswerKeyValueForId: function(answerId, key) {
+        /*
+        Return a value corresponding with the passed `key` from the answer
+        object at `answerId.`
+        */
+        return _.result(_.find(this.answers, {id: answerId}), key);
+      },
+      getSimpleAnswersForQuestions: function(questions) {
+        /*
+        Return an answers object in a simplified form:
+
+        [
+          {
+            'id': '<question id>',
+            'value': '<answer value>',
+            'commentValue': '<comment value>'
+          },
+          {...}
+        ]
+
+        Simplifies some answer values, such as multiple choice answers to a
+        list of chosen values.
+        */
+        let answers = _.map(questions, q => {
+          return {
+            id: q.id,
+            value: this.getAnswerValueForQuestion(q),
+            commentValue: this.getAnswerKeyValueForId(q.id, 'commentValue')
+          };
+        });
+        return answers;
+      },
       getAnswerValueForQuestion: function(q) {
         // Find the `value` property for the answer with `id`.
-        let answer = _.result(_.find(this.answers, {id: q.id}), 'value');
+        let answer = this.getAnswerKeyValueForId(q.id, 'value');
         // Multiple-choice answers need special treatment to get the checked
         // answers.
         if (q.type === 'multiple') {

--- a/census/views/base.html
+++ b/census/views/base.html
@@ -137,10 +137,10 @@
         {% endif %}
         <div class="footer-secondary">
           <p class="pull-right">
-{#             <strong>{{ gettext("Download") }}:</strong> <a href="/api/entries.cascade.csv">{{ gettext("Current (CSV)") }}</a> |
+            <strong>{{ gettext("Download") }}:</strong> <a href="/api/entries.cascade.csv">{{ gettext("Current (CSV)") }}</a> |
             <a href="/api/entries.csv">{{ gettext("All (CSV)") }}</a> |
             <a href="/api/entries.cascade.json">{{ gettext("Current (JSON)") }}</a> |
-            <a href="/api/entries.json">{{ gettext("All (JSON)") }}</a> #}
+            <a href="/api/entries.json">{{ gettext("All (JSON)") }}</a>
           </p>
           <p>
             <a href="http://opendatacommons.org/licenses/pddl/1.0">Data License (Public Domain)</a>. <a href="https://github.com/okfn/opendatacensus/">Source code</a>.

--- a/fixtures/entry.js
+++ b/fixtures/entry.js
@@ -18,31 +18,31 @@ const formatAnswers = [
 ];
 
 function answers() {
-  return {
-    digital: {id: 'digital', value: true, commentValue: ''},
-    exists: {id: 'exists', value: 'Yes', commentValue: ''},
-    machinereadable: {id: 'machinereadable', value: true, commentValue: ''},
-    openlicense: {id: 'openlicense', value: false, commentValue: ''},
-    online: {id: 'online', value: false, commentValue: ''},
-    public: {id: 'public', value: false, commentValue: ''},
-    publisher: {id: 'publisher', value: 'Acme', commentValue: ''},
-    format: {id: 'format', value: formatAnswers, commentValue: ''},
-    license: {id: 'license', value: 'http://example.com', commentValue: ''}
-  };
+  return [
+    {id: 'digital', value: true, commentValue: ''},
+    {id: 'exists', value: 'Yes', commentValue: ''},
+    {id: 'machinereadable', value: true, commentValue: ''},
+    {id: 'openlicense', value: false, commentValue: ''},
+    {id: 'online', value: false, commentValue: ''},
+    {id: 'public', value: false, commentValue: ''},
+    {id: 'publisher', value: 'Acme', commentValue: ''},
+    {id: 'format', value: formatAnswers, commentValue: ''},
+    {id: 'license', value: 'http://example.com', commentValue: ''}
+  ];
 }
 
 function currentAnswers() {
-  return {
-    digital: {id: 'digital', value: false, commentValue: ''},
-    exists: {id: 'exists', value: false, commentValue: ''},
-    machinereadable: {id: 'machinereadable', value: false, commentValue: ''},
-    openlicense: {id: 'openlicense', value: true, commentValue: ''},
-    online: {id: 'online', value: true, commentValue: ''},
-    public: {id: 'public', value: true, commentValue: ''},
-    publisher: {id: 'publisher', value: 'Acme', commentValue: ''},
-    format: {id: 'format', value: formatAnswers, commentValue: ''},
-    license: {id: 'license', value: 'http://example.com', commentValue: ''}
-  };
+  return [
+    {id: 'digital', value: false, commentValue: ''},
+    {id: 'exists', value: false, commentValue: ''},
+    {id: 'machinereadable', value: false, commentValue: ''},
+    {id: 'openlicense', value: true, commentValue: ''},
+    {id: 'online', value: true, commentValue: ''},
+    {id: 'public', value: true, commentValue: ''},
+    {id: 'publisher', value: 'Acme', commentValue: ''},
+    {id: 'format', value: formatAnswers, commentValue: ''},
+    {id: 'license', value: 'http://example.com', commentValue: ''}
+  ];
 }
 
 function bySite(fixtures, siteId) {

--- a/tests/api.js
+++ b/tests/api.js
@@ -27,9 +27,9 @@ let checkCsvResponse = function(browser, expectedLength) {
   // CSV will contain headers (at least)
   assert.notEqual(resource.body, '');
   if (expectedLength) {
-    // expectedLength + 1 (the header line)
-    assert.equal(_.trimRight(resource.body, '\n').split('\n').length,
-                 expectedLength + 1);
+    // actual length - 1 (the header line)
+    assert.equal(_.trimRight(resource.body, '\n').split('\n').length - 1,
+                 expectedLength);
   }
 };
 
@@ -57,31 +57,35 @@ describe('API', function() {
       describe('Format: ' + format, () => {
         this.timeout(20000);
 
-        it('All', () => {
+        it('All', done => {
           let browser = testUtils.browser;
           browser.visit('/api/entries.all.' + format, () => {
-            checkResponse(browser);
+            checkResponse(browser, 8);
+            done();
           });
         });
 
-        it('All current', () => {
+        it('All current', done => {
           let browser = testUtils.browser;
           browser.visit('/api/entries.' + format, () => {
-            checkResponse(browser);
+            checkResponse(browser, 4);
+            done();
           });
         });
 
-        it('Current cascaded', () => {
+        it('Current cascaded', done => {
           let browser = testUtils.browser;
           browser.visit('/api/entries.cascade.' + format, () => {
-            checkResponse(browser);
+            checkResponse(browser, 4);
+            done();
           });
         });
 
-        it('All current, year: ' + year, () => {
+        it('All current, year: ' + year, done => {
           let browser = testUtils.browser;
           browser.visit('/api/entries/' + year + '.' + format, () => {
-            checkResponse(browser);
+            checkResponse(browser, 3);
+            done();
           });
         });
 
@@ -89,7 +93,7 @@ describe('API', function() {
           let browser = testUtils.browser;
           browser.visit('/api/entries/' + year + '.cascade.' + format,
             () => {
-              checkResponse(browser);
+              checkResponse(browser, 4);
               done();
             });
         });

--- a/tests/api.js
+++ b/tests/api.js
@@ -1,28 +1,28 @@
 'use strict';
 
-var _ = require('lodash');
-var assert = require('chai').assert;
-var testUtils = require('./utils');
+const _ = require('lodash');
+const assert = require('chai').assert;
+const testUtils = require('./utils');
 
-function checkJsonResponse(browser) {
+let checkJsonResponse = function(browser) {
   assert.ok(browser.success);
   assert.equal(browser.resources.length, 1);
-  var resource = browser.resources[0].response;
+  let resource = browser.resources[0].response;
   assert.include(resource.headers.get('Content-Type'), '/json');
   // JSON will contain '{}' even on completely empty results set
   assert.notEqual(resource.body, '');
-}
+};
 
-function checkCsvResponse(browser) {
+let checkCsvResponse = function(browser) {
   assert.ok(browser.success);
   assert.equal(browser.resources.length, 1);
-  var resource = browser.resources[0].response;
+  let resource = browser.resources[0].response;
   assert.include(resource.headers.get('Content-Type'), '/csv');
   // CSV will contain headers (at least)
   assert.notEqual(resource.body, '');
-}
+};
 
-var responseFormats = {
+let responseFormats = {
   json: checkJsonResponse,
   csv: checkCsvResponse
 };
@@ -39,57 +39,53 @@ describe('API', function() {
   // 4. response should contain requested data.
 
   describe('Entries', function() {
-    var year = 2015;
-    _.forEach(_.keys(responseFormats), function(format) {
-      var checkResponse = responseFormats[format];
+    const year = 2015;
+    _.forEach(_.keys(responseFormats), format => {
+      const checkResponse = responseFormats[format];
 
-      describe('Format: ' + format, function() {
+      describe('Format: ' + format, () => {
         this.timeout(20000);
 
-        it('All', function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/entries.all.' + format, function() {
+        it('All', () => {
+          let browser = testUtils.browser;
+          browser.visit('/api/entries.all.' + format, () => {
             checkResponse(browser);
-            done();
           });
         });
 
-        it('All current', function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/entries.' + format, function() {
+        it('All current', () => {
+          let browser = testUtils.browser;
+          browser.visit('/api/entries.' + format, () => {
             checkResponse(browser);
-            done();
           });
         });
 
-        it('Current cascaded', function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/entries.cascade.' + format, function() {
+        it('Current cascaded', () => {
+          let browser = testUtils.browser;
+          browser.visit('/api/entries.cascade.' + format, () => {
             checkResponse(browser);
-            done();
           });
         });
 
-        it('All current, year: ' + year, function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/entries/' + year + '.' + format, function() {
+        it('All current, year: ' + year, () => {
+          let browser = testUtils.browser;
+          browser.visit('/api/entries/' + year + '.' + format, () => {
             checkResponse(browser);
-            done();
           });
         });
 
-        it('Current cascaded, year: ' + year, function(done) {
-          var browser = testUtils.browser;
+        it('Current cascaded, year: ' + year, done => {
+          let browser = testUtils.browser;
           browser.visit('/api/entries/' + year + '.cascade.' + format,
-            function() {
+            () => {
               checkResponse(browser);
               done();
             });
         });
 
-        it('Should fail on invalid strategy', function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/entries.invalid.' + format, function() {
+        it('Should fail on invalid strategy', done => {
+          let browser = testUtils.browser;
+          browser.visit('/api/entries.invalid.' + format, () => {
             assert.equal(browser.status, 404);
             done();
           });
@@ -99,39 +95,31 @@ describe('API', function() {
   });
 
   describe('Entries (data)', function() {
-
-    it('All current', function(done) {
-      var browser = testUtils.browser;
-      browser.visit('/api/entries.json', function() {
-
+    it('All current', done => {
+      let browser = testUtils.browser;
+      browser.visit('/api/entries.json', () => {
         // Get first item
         browser.assert.success();
-        var data = JSON.parse(browser.text());
-        var item = data['results'][0];
-
+        const data = JSON.parse(browser.text());
+        const item = data.results[0];
         // Check data is right
         assert.equal(item.reviewComments, '');
         assert.include(['Yes', 'No'], item.reviewed);
         assert.include(['Yes', 'No'], item.reviewResult);
         assert.include(['Yes', 'No'], item.isCurrent);
         assert.include(['Yes', 'No'], item.isOpen);
-
         done();
-
       });
     });
-
   });
 
   describe('Places', function() {
-    var year = 2015;
-    _.forEach(_.keys(responseFormats), function(format) {
-      var checkResponse = responseFormats[format];
-
-      describe('Format: ' + format, function() {
-        it('All', function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/places.' + format, function() {
+    _.forEach(_.keys(responseFormats), format => {
+      let checkResponse = responseFormats[format];
+      describe('Format: ' + format, () => {
+        it('All', done => {
+          let browser = testUtils.browser;
+          browser.visit('/api/places.' + format, () => {
             checkResponse(browser);
             done();
           });
@@ -141,14 +129,12 @@ describe('API', function() {
   });
 
   describe('Datasets', function() {
-    var year = 2015;
-    _.forEach(_.keys(responseFormats), function(format) {
-      var checkResponse = responseFormats[format];
-
-      describe('Format: ' + format, function() {
-        it('All', function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/datasets.' + format, function() {
+    _.forEach(_.keys(responseFormats), format => {
+      let checkResponse = responseFormats[format];
+      describe('Format: ' + format, () => {
+        it('All', done => {
+          let browser = testUtils.browser;
+          browser.visit('/api/datasets.' + format, () => {
             checkResponse(browser);
             done();
           });
@@ -158,14 +144,12 @@ describe('API', function() {
   });
 
   describe('Questions', function() {
-    var year = 2015;
-    _.forEach(_.keys(responseFormats), function(format) {
-      var checkResponse = responseFormats[format];
-
-      describe('Format: ' + format, function() {
-        it('All', function(done) {
-          var browser = testUtils.browser;
-          browser.visit('/api/questions.' + format, function() {
+    _.forEach(_.keys(responseFormats), format => {
+      let checkResponse = responseFormats[format];
+      describe('Format: ' + format, () => {
+        it('All', done => {
+          let browser = testUtils.browser;
+          browser.visit('/api/questions.' + format, () => {
             checkResponse(browser);
             done();
           });

--- a/tests/api.js
+++ b/tests/api.js
@@ -123,6 +123,15 @@ describe('API', function() {
         assert.include(['Yes', 'No'], item.reviewResult);
         assert.include(['Yes', 'No'], item.isCurrent);
         assert.include(['Yes', 'No'], item.isOpen);
+        assert.isArray(item.answers);
+        // one answer for each question
+        assert.equal(item.answers.length, 18);
+        // answer object has correct structure
+        assert.deepEqual(_.keys(item.answers[0]),
+                         ['id', 'value', 'commentValue']);
+        // check `format` answer (multiple choice question)
+        assert.deepEqual(_.find(item.answers, 'id', 'format').value,
+                         ['AsciiDoc', 'CSV', 'HTML']);
         done();
       });
     });

--- a/tests/api.js
+++ b/tests/api.js
@@ -38,7 +38,7 @@ let responseFormats = {
   csv: checkCsvResponse
 };
 
-describe.only('API', function() {
+describe('API', function() {
   before(testUtils.startApplication);
   after(testUtils.shutdownApplication);
 

--- a/tests/api.js
+++ b/tests/api.js
@@ -161,7 +161,7 @@ describe('API', function() {
         it('All', done => {
           let browser = testUtils.browser;
           browser.visit('/api/questions.' + format, () => {
-            checkResponse(browser);
+            checkResponse(browser, 18);
             done();
           });
         });


### PR DESCRIPTION
This PR ensures the various API endpoints (Places, Datasets, Questions, and Entries) continue to return results, and reintroduces the Entry endpoint links in the base template. Some changes to instance properties are necessary to reflect changes in model structure:

Datasets:
- add `updateevery` property (string)
- add `characteristics` property (list of strings)

Questions:
- now returns all Questions (previously only returned scored Questions)
- add `openquestion` property (bool)
- add `config` property (json object)
- add `questionshort` (string)
- remove `order`, now defined by the `QuestionSet`

Entries:
- add `relativeScore` (number)
- move answer properties to a dedicated `answer` property as a json collection:
```json
[
  {
    "id": "<question id>",
    "value": "<answer value>",
    "commentValue": "<comment value>"
  },
  {...}
]
```

Fixes #846.