### PR TITLE
Prepare templates and js files for localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,20 @@ We run deployments on Heroku. The app should run anywhere that you can run Node.
 
 When templates change, the translations have to be changed. Extract the files by running this command:
 
-    gulp pot
+    ./node_modules/.bin/gulp pot
 
 You will need the GNU gettext commands. See [here](https://github.com/mozilla/i18n-abide/blob/master/docs/GETTEXT.md) for more information.
 
 To update the existing .po files, run:
 
-    gulp update-po
+    ./node_modules/.bin/gulp update-po
 
 To add a new language, create directory `locale/[language-code]/LC_MESSAGES` and put there translation files (*.po).
 Also, you can copy the `locale/en` directory to `locale/[language-code]` and change existing files.
 
 To update translations cache, run
 
-    gulp compile-po
+    ./node_modules/.bin/gulp compile-po
 
 ### i18n For Config
 

--- a/census/controllers/census.js
+++ b/census/controllers/census.js
@@ -80,7 +80,7 @@ var submitGet = function(req, res, data) {
       datasetContext: datasetContext,
       formData: formData,
       initialRenderedEntry: initialHTML,
-      breadcrumbTitle: 'Make a Submission',
+      breadcrumbTitle: req.gettext('Make a Submission'),
       submitInstructions: marked(submitInstructions),
       errors: _.get(data, 'errors'),
       isReview: false
@@ -100,9 +100,9 @@ var submitPost = function(req, res, data) {
 
   if (pending) {
     if (!Array.isArray(errors)) errors = [];
-    let msg = util.format('There is already a queued submission for this data. ' +
-                          '<a href="/place/%s/%s">See the queued submission</a>.',
-                          current.place, req.params.year);
+    let msg = req.format(req.gettext('There is already a queued submission for this data. ' +
+                                     '<a href="/place/%s/%s">See the queued submission</a>.'),
+                          [current.place, req.params.year]);
     errors.push({
       param: 'conflict',
       msg: msg
@@ -184,19 +184,19 @@ var submitPost = function(req, res, data) {
       let submissionPath;
 
       if (result) {
-        let msgTmpl = 'Thanks for your submission.%s You can check ' +
-          'back here any time to see the current status.';
+        let msgTmpl = req.gettext('Thanks for your submission.%s You can check ' +
+                  'back here any time to see the current status.');
         submissionPath = '/submission/' + result.id;
         if (result.isCurrent) {
           msg = util.format(msgTmpl, '');
           redirectPath = '/place/' + result.place;
         } else {
-          msg = util.format(msgTmpl, ' It will now be reviewed by the editors.');
+          msg = util.format(msgTmpl, req.gettext(' It will now be reviewed by the editors.'));
           redirectPath = submissionPath;
         }
         req.flash('info', msg);
       } else {
-        msg = 'There was an error!';
+        msg = req.gettext('There was an error!');
         req.flash('error', msg);
       }
 
@@ -243,8 +243,8 @@ let _getDiscussionURL = function(req, dataset, place) {
       newTopicURL.host = parsedURL.host;
       newTopicURL.pathname = 'new-topic';
       newTopicURL.search = querystring.stringify({
-        title: util.format('Entry for %s / %s', dataset, place),
-        body: util.format('This is a discussion about the submission for [%s / %s](%s).',
+        title: util.format(req.gettext('Entry for %s / %s'), dataset, place),
+        body: util.format(req.gettext('This is a discussion about the submission for [%s / %s](%s).'),
                           dataset, place, req.res.locals.current_url),
         category: _.rest(splitPathName).join('/').replace(/-/g, ' ')
       });
@@ -266,7 +266,8 @@ var pending = function(req, res) {
   req.app.get('models').Entry.findOne(entryQueryParams)
   .then(entry => {
     if (!entry) {
-      res.status(404).send('There is no submission with id ' + req.params.id);
+      res.status(404).send(util.format(req.gettext('There is no submission with id %s'),
+                           req.params.id));
       return;
     }
     let dataOptions = _.merge(modelUtils.getDataOptions(req), {
@@ -353,7 +354,7 @@ var pending = function(req, res) {
         datasetContext: datasetContext,
         formData: formData,
         initialRenderedEntry: initialHTML,
-        breadcrumbTitle: 'Review a Submission',
+        breadcrumbTitle: req.gettext('Review a Submission'),
         submitInstructions: config.get('review_page'),
         submissionDiscussionURL: submissionDiscussionURL,
         errors: _.get(data, 'errors'),
@@ -373,7 +374,8 @@ var reviewPost = function(req, res) {
   req.app.get('models').Entry.findById(req.params.id)
   .then(entry => {
     if (!entry) {
-      res.status(404).send('There is no entry with id ' + req.params.id);
+      res.status(404).send(util.format(req.gettext('There is no entry with id %s'),
+                           req.params.id));
       return;
     }
 
@@ -395,7 +397,7 @@ var reviewPost = function(req, res) {
 
     data.reviewers = utils.getReviewers(req, data);
     if (!utils.canReview(data.reviewers, req.user)) {
-      res.status(403).send('You are not allowed to review this entry.');
+      res.status(403).send(req.gettext('You are not allowed to review this entry.'));
       return;
     }
     entry.reviewerId = req.user.id;
@@ -428,10 +430,10 @@ var reviewPost = function(req, res) {
   .then(acceptSubmission => {
     // Set the flash message and redirect to homepage.
     if (acceptSubmission) {
-      let msg = 'Submission processed and entered into the census.';
+      let msg = req.gettext('Submission processed and entered into the census.');
       req.flash('info', msg);
     } else {
-      let msg = 'Submission marked as rejected.';
+      let msg = req.gettext('Submission marked as rejected.');
       req.flash('info', msg);
     }
     res.redirect('/');

--- a/census/controllers/mixins.js
+++ b/census/controllers/mixins.js
@@ -43,8 +43,8 @@ var requireDomain = function(req, res, next) {
 
   if (!req.params.domain) {
     res.status(404).render('404.html', {
-      title: 'Not found',
-      message: 'Not found'
+      title: req.gettext('Not found'),
+      message: req.gettext('Not found')
     });
   } else
   if (req.params.domain === req.app.get('authDomain') ||
@@ -61,7 +61,7 @@ var requireDomain = function(req, res, next) {
         if (!result) {
           res.status(404).send({
             status: 'error',
-            message: 'There is no matching census in the registry.'
+            message: req.gettext('There is no matching census in the registry.')
           });
         } else {
           req.session.activeSite = req.params.domain;
@@ -101,7 +101,7 @@ var requireDomain = function(req, res, next) {
       .catch(function() {
         res.status(404).send({
           status: 'error',
-          message: 'There is no matching census in the registry.'
+          message: req.gettext('There is no matching census in the registry.')
         });
       });
   }
@@ -132,7 +132,7 @@ var requireAdmin = function(req, res, next) {
   } else {
     res.status(403).send({
       status: 'error',
-      message: 'not allowed'
+      message: req.gettext('Not allowed')
     });
   }
 };
@@ -156,7 +156,7 @@ var requireAvailableYear = function(req, res, next) {
     if (_.indexOf(req.app.get('years'), req.params.year) === -1) {
       res.status(404).send({
         status: 'not found',
-        message: 'not found here'
+        message: req.gettext('Not found here')
       });
       return;
     }

--- a/census/controllers/pages.js
+++ b/census/controllers/pages.js
@@ -27,13 +27,13 @@ var faq = function(req, res) {
       });
       var settingName = 'missing_place_html';
       var mContent = req.params.site.settings[settingName];
-      data.title = 'FAQ - Frequently Asked Questions';
+      data.title = req.gettext('FAQ - Frequently Asked Questions');
       settingName = 'faq_page';
       data.content = marked(req.params.site.settings[settingName])
         .replace('{{questions}}', qContent)
         .replace('{{datasets}}', dContent)
         .replace('{{missing_place}}', mContent);
-      data.breadcrumbTitle = 'FAQ';
+      data.breadcrumbTitle = req.gettext('FAQ');
       return res.render('page.html', data);
     }).catch(console.trace.bind(console));
 };
@@ -48,7 +48,7 @@ var changes = function(req, res) {
       data.items = _.sortByOrder(data.entries
         .concat(data.pending)
         .concat(data.rejected), 'updatedAt', 'desc');
-      data.breadcrumbTitle = 'Recent Changes';
+      data.breadcrumbTitle = req.gettext('Recent Changes');
       res.render('changes.html', data);
     }).catch(console.trace.bind(console));
 };
@@ -57,8 +57,8 @@ var contribute = function(req, res) {
   var settingName = 'contribute_page';
   res.render('page.html', {
     content: marked(req.params.site.settings[settingName]),
-    title: 'Contribute',
-    breadcrumbTitle: 'Contribute'
+    title: req.gettext('Contribute'),
+    breadcrumbTitle: req.gettext('Contribute')
   });
 };
 
@@ -66,8 +66,8 @@ var methodology = function(req, res) {
   var settingName = 'methodology_page';
   res.render('page.html', {
     content: marked(req.params.site.settings[settingName]),
-    title: 'Methodology',
-    breadcrumbTitle: 'Methodology'
+    title: req.gettext('Methodology'),
+    breadcrumbTitle: req.gettext('Methodology')
   });
 };
 
@@ -75,8 +75,8 @@ var tutorial = function(req, res) {
   var settingName = 'tutorial_page';
   res.render('page.html', {
     content: marked(req.params.site.settings[settingName]),
-    title: 'Tutorial',
-    breadcrumbTitle: 'Tutorial'
+    title: req.gettext('Tutorial'),
+    breadcrumbTitle: req.gettext('Tutorial')
   });
 };
 
@@ -84,8 +84,8 @@ var about = function(req, res) {
   var settingName = 'about_page';
   res.render('page.html', {
     content: marked(req.params.site.settings[settingName]),
-    title: 'About',
-    breadcrumbTitle: 'About'
+    title: req.gettext('About'),
+    breadcrumbTitle: req.gettext('About')
   });
 };
 
@@ -117,9 +117,9 @@ var place = function(req, res) {
     .then(function(data) {
       if (!data.place) {
         return res.status(404)
-          .send('There is no matching place in our database. ' +
-                'Are you sure it is spelled correctly? Please check the ' +
-                '<a href="/">overview page</a> for the list of places.');
+          .send(req.gettext('There is no matching place in our database. ' +
+                            'Are you sure it is spelled correctly? Please check the ' +
+                            '<a href="/">overview page</a> for the list of places.'));
       }
 
       data.urlContext = '';
@@ -144,9 +144,9 @@ var dataset = function(req, res) {
     .then(function(data) {
       if (!data.dataset) {
         return res.status(404)
-          .send('There is no matching dataset in our database. ' +
-                'Are you sure it is spelled correctly? Please check the ' +
-                '<a href="/">overview page</a> for the list of datasets.');
+          .send(req.gettext('There is no matching dataset in our database. ' +
+                            'Are you sure it is spelled correctly? Please check the ' +
+                            '<a href="/">overview page</a> for the list of datasets.'));
       }
 
       data.urlContext = '';
@@ -175,9 +175,9 @@ var entry = function(req, res) {
       data.entry = _.first(data.entries);
       if (!data.entry) {
         return res.status(404)
-          .send('There is no matching entry in our database. ' +
-                'Are you sure you have spelled it correctly? Please check the ' +
-                '<a href="/">overview page</a> for the list of places');
+          .send(req.gettext('There is no matching entry in our database. ' +
+                            'Are you sure you have spelled it correctly? Please check the ' +
+                            '<a href="/">overview page</a> for the list of places'));
       }
 
       data.urlContext = '';

--- a/census/locale/templates/LC_MESSAGES/messages.pot
+++ b/census/locale/templates/LC_MESSAGES/messages.pot
@@ -2,15 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-07 15:57+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2016-12-08T15:23:40.826Z\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language: \n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"MIME-Version: 1.0\n"
 
 #: views/base.html:46
 #: views/macros/breadcrumb.html:5
@@ -40,6 +39,8 @@ msgstr ""
 
 #: views/base.html:72
 #: views/dataset.html:62
+#: controllers/pages.js:87
+#: controllers/pages.js:88
 msgid "About"
 msgstr ""
 
@@ -48,18 +49,25 @@ msgid "Changes"
 msgstr ""
 
 #: views/base.html:74
+#: controllers/pages.js:36
 msgid "FAQ"
 msgstr ""
 
 #: views/base.html:76
+#: controllers/pages.js:69
+#: controllers/pages.js:70
 msgid "Methodology"
 msgstr ""
 
 #: views/base.html:79
+#: controllers/pages.js:60
+#: controllers/pages.js:61
 msgid "Contribute"
 msgstr ""
 
 #: views/base.html:82
+#: controllers/pages.js:78
+#: controllers/pages.js:79
 msgid "Tutorial"
 msgstr ""
 
@@ -125,6 +133,7 @@ msgid "Change language:"
 msgstr ""
 
 #: views/changes.html:4
+#: controllers/pages.js:51
 msgid "Recent Changes"
 msgstr ""
 
@@ -219,6 +228,58 @@ msgstr ""
 msgid "Got it"
 msgstr ""
 
+#: controllers/census.js:83
+msgid "Make a Submission"
+msgstr ""
+
+#: controllers/census.js:103
+msgid "There is already a queued submission for this data. <a href=\"/place/%s/%s\">See the queued submission</a>."
+msgstr ""
+
+#: controllers/census.js:187
+msgid "Thanks for your submission.%s You can check back here any time to see the current status."
+msgstr ""
+
+#: controllers/census.js:194
+msgid " It will now be reviewed by the editors."
+msgstr ""
+
+#: controllers/census.js:199
+msgid "There was an error!"
+msgstr ""
+
+#: controllers/census.js:246
+msgid "Entry for %s / %s"
+msgstr ""
+
+#: controllers/census.js:247
+msgid "This is a discussion about the submission for [%s / %s](%s)."
+msgstr ""
+
+#: controllers/census.js:269
+msgid "There is no submission with id %s"
+msgstr ""
+
+#: controllers/census.js:357
+msgid "Review a Submission"
+msgstr ""
+
+#: controllers/census.js:377
+msgid "There is no entry with id %s"
+msgstr ""
+
+#: controllers/census.js:400
+msgid "You are not allowed to review this entry."
+msgstr ""
+
+#: controllers/census.js:433
+msgid "Submission processed and entered into the census."
+msgstr ""
+
+#: controllers/census.js:436
+msgid "Submission marked as rejected."
+msgstr ""
+
 #: views/dataset.html:11
 #: views/place.html:11
 msgid "%(score)s% open (avg.)"
@@ -290,6 +351,24 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
+#: controllers/mixins.js:46
+#: controllers/mixins.js:47
+msgid "Not found"
+msgstr ""
+
+#: controllers/mixins.js:64
+#: controllers/mixins.js:104
+msgid "There is no matching census in the registry."
+msgstr ""
+
+#: controllers/mixins.js:135
+msgid "Not allowed"
+msgstr ""
+
+#: controllers/mixins.js:159
+msgid "Not found here"
+msgstr ""
+
 #: views/login.html:15
 msgid "Please login to contribute to the Census."
 msgstr ""
@@ -308,6 +387,22 @@ msgstr ""
 
 #: views/login.html:32
 msgid "terms of use"
+msgstr ""
+
+#: controllers/pages.js:30
+msgid "FAQ - Frequently Asked Questions"
+msgstr ""
+
+#: controllers/pages.js:120
+msgid "There is no matching place in our database. Are you sure it is spelled correctly? Please check the <a href=\"/\">overview page</a> for the list of places."
+msgstr ""
+
+#: controllers/pages.js:147
+msgid "There is no matching dataset in our database. Are you sure it is spelled correctly? Please check the <a href=\"/\">overview page</a> for the list of datasets."
+msgstr ""
+
+#: controllers/pages.js:178
+msgid "There is no matching entry in our database. Are you sure you have spelled it correctly? Please check the <a href=\"/\">overview page</a> for the list of places"
 msgstr ""
 
 #: views/overview.html:17
@@ -369,18 +464,6 @@ msgstr ""
 
 #: views/place.html:15
 msgid "Ranked #1 against other places in the Index (avg.)"
-msgstr ""
-
-#: views/test.html:3
-msgid "hello"
-msgstr ""
-
-#: views/test.html:5
-msgid "that"
-msgstr ""
-
-#: views/test.html:7
-msgid "Submitted by %s and reviewed by %s"
 msgstr ""
 
 #: views/includes/godi-home.html:3

--- a/census/locale/templates/LC_MESSAGES/messages.pot
+++ b/census/locale/templates/LC_MESSAGES/messages.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-14 14:03+0000\n"
+"POT-Creation-Date: 2016-12-07 15:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: \n"
@@ -12,561 +12,484 @@ msgstr ""
 "Plural-Forms: \n"
 "MIME-Version: 1.0\n"
 
-#: templates/base.html:39
+#: views/base.html:46
+#: views/macros/breadcrumb.html:5
 msgid "Home"
 msgstr ""
 
-#: templates/base.html:40
-msgid "About"
+#: views/base.html:47
+msgid "Powered by <a href='%s'>Open Data Census</a>"
 msgstr ""
 
-#: templates/base.html:41
-msgid "Changes"
+#: views/base.html:53
+msgid "Toggle navigation"
 msgstr ""
 
-#: templates/base.html:43
-msgid "FAQ"
-msgstr ""
-
-#: templates/base.html:46
-msgid "Contribute"
-msgstr ""
-
-#: templates/base.html:95
-msgid "Change language:"
-msgstr ""
-
-#: templates/base.html:106
-msgid "Open Online Software Service"
-msgstr ""
-
-#: templates/base.html:109
-#: templates/base.html:112
-msgid "Open Definition"
-msgstr ""
-
-#: templates/base.html:116
-msgid "Data License (Public Domain)"
-msgstr ""
-
-#: templates/base.html:118
-msgid "Source code"
-msgstr ""
-
-#: templates/base.html:121
-msgid "Download Data (CSV)"
-msgstr ""
-
-#: templates/base.html:123
-msgid "Download Data (JSON)"
-msgstr ""
-
-#: templates/base.html:126
-msgid "Part of the <a href=\"http://census.okfn.org/\">Open Data Census project</a> run by Open Knowledge."
-msgstr ""
-
-#: templates/base.html:129
-msgid "An Open Knowledge Project"
-msgstr ""
-
-#: templates/base.html:138
-msgid "Logged in as %(name)s."
-msgstr ""
-
-#: templates/base.html:139
+#: views/base.html:64
+#: views/base.html:152
 msgid "Log out"
 msgstr ""
 
-#: templates/base.html:141
-#: templates/login.html:4
-#: templates/login.html:9
-#: templates/submission/review.html:20
+#: views/base.html:66
+#: views/base.html:154
+#: views/create.html:85
+#: views/login.html:4
+#: views/login.html:11
 msgid "Login"
 msgstr ""
 
-#: templates/base.html:144
-msgid "More about Open Data"
+#: views/base.html:72
+#: views/dataset.html:62
+msgid "About"
 msgstr ""
 
-#: templates/base.html:144
+#: views/base.html:73
+msgid "Changes"
+msgstr ""
+
+#: views/base.html:74
+msgid "FAQ"
+msgstr ""
+
+#: views/base.html:76
+msgid "Methodology"
+msgstr ""
+
+#: views/base.html:79
+msgid "Contribute"
+msgstr ""
+
+#: views/base.html:82
+msgid "Tutorial"
+msgstr ""
+
+#: views/base.html:85
+#: views/base.html:87
+msgid "Support"
+msgstr ""
+
+#: views/base.html:125
+msgid "Privacy policy"
+msgstr ""
+
+#: views/base.html:126
+msgid "IP policy"
+msgstr ""
+
+#: views/base.html:127
+msgid "Cookie policy"
+msgstr ""
+
+#: views/base.html:128
+msgid "Terms of use"
+msgstr ""
+
+#: views/base.html:129
 msgid "What is Open Data"
 msgstr ""
 
-#: templates/base.html:145
-msgid "Run Your Own<br />Local Open Data Census"
+#: views/base.html:130
+msgid "Run Your Own Local Open Data Census"
 msgstr ""
 
-#: templates/changes.html:4
+#: views/base.html:140
+msgid "Download"
+msgstr ""
+
+#: views/base.html:140
+msgid "Current (CSV)"
+msgstr ""
+
+#: views/base.html:141
+msgid "All (CSV)"
+msgstr ""
+
+#: views/base.html:142
+msgid "Current (JSON)"
+msgstr ""
+
+#: views/base.html:143
+msgid "All (JSON)"
+msgstr ""
+
+#: views/base.html:146
+msgid "Data License (Public Domain)"
+msgstr ""
+
+#: views/base.html:146
+msgid "Source code"
+msgstr ""
+
+#: views/base.html:158
+msgid "Change language:"
+msgstr ""
+
+#: views/changes.html:4
 msgid "Recent Changes"
 msgstr ""
 
-#: templates/changes.html:8
+#: views/changes.html:9
 msgid "Changelog"
 msgstr ""
 
-#: templates/changes.html:10
+#: views/changes.html:11
 msgid "A log of the most recent submission and entry activity."
 msgstr ""
 
-#: templates/changes.html:16
-msgid "Entry"
-msgstr ""
-
-#: templates/changes.html:16
-#: templates/submission/review.html:29
-msgid "Submission"
-msgstr ""
-
-#: templates/changes.html:18
-msgid "new"
-msgstr ""
-
-#: templates/changes.html:26
-msgid "On"
-msgstr ""
-
-#: templates/changes.html:26
-msgid "submitted by"
-msgstr ""
-
-#: templates/changes.html:26
-msgid "and reviewed by"
-msgstr ""
-
-#: templates/login.html:20
-msgid "Please login to contribute to the"
-msgstr ""
-
-#: templates/login.html:25
-msgid "Login with Google &raquo;"
-msgstr ""
-
-#: templates/login.html:27
-msgid "Login with your existing Google account in a few seconds. We will not share your email with any third party. For more information see the"
-msgstr ""
-
-#: templates/login.html:27
-msgid "terms of use"
-msgstr ""
-
-#: templates/login.html:31
-msgid "&ndash; or &ndash;"
-msgstr ""
-
-#: templates/login.html:36
-msgid "Name (optional)"
-msgstr ""
-
-#: templates/login.html:37
-msgid "If you provide a name we can credit you for your contribution (if not provided you'll be listed as Anonymous)."
-msgstr ""
-
-#: templates/login.html:38
-msgid "Joe Bloggs"
-msgstr ""
-
-#: templates/login.html:40
-msgid "Continue &raquo;"
-msgstr ""
-
-#: templates/login.html:43
-msgid "Continue without logging in."
-msgstr ""
-
-#: templates/overview.html:3
-msgid "Overview"
-msgstr ""
-
-#: templates/overview.html:11
-msgid "Number of places"
-msgstr ""
-
-#: templates/overview.html:13
-msgid "Number of datasets"
-msgstr ""
-
-#: templates/overview.html:15
-msgid "Number of open datasets"
-msgstr ""
-
-#: templates/overview.html:17
-msgid "Percentage"
-msgstr ""
-
-#: templates/overview.html:17
-msgid "open"
-msgstr ""
-
-#: templates/overview.html:34
-msgid "Add information"
-msgstr ""
-
-#: templates/overview.html:50
-#: templates/overview.html:121
-msgid "Total Score"
-msgstr ""
-
-#: templates/overview.html:58
-msgid "The Census Admin needs to add some places to the Places configuration sheet"
-msgstr ""
-
-#: templates/overview.html:80
-msgid "Click here to add to the census!"
-msgstr ""
-
-#: templates/overview.html:80
-msgid "Add new"
-msgstr ""
-
-#: templates/_snippets/datasets.html:4
-#: templates/country/place.html:39
-#: templates/submission/create.html:47
-msgid "Dataset"
-msgstr ""
-
-#: templates/_snippets/datasets.html:5
-#: templates/_snippets/entry-summary-row.html:55
-#: templates/_snippets/questions.html:5
-#: templates/country/entry.html:57
-msgid "Details"
-msgstr ""
-
-#: templates/_snippets/entry-summary-row.html:36
-msgid "Date available:"
-msgstr ""
-
-#: templates/_snippets/entry-summary-row.html:38
-msgid "No date available given"
-msgstr ""
-
-#: templates/_snippets/entry-summary-row.html:47
-msgid "No data format given"
-msgstr ""
-
-#: templates/_snippets/entry-summary-row.html:59
-msgid "No details"
-msgstr ""
-
-#: templates/_snippets/key.html:2
-msgid "Key:"
-msgstr ""
-
-#: templates/_snippets/key.html:4
-#: templates/submission/form-core.html:38
-msgid "Yes"
-msgstr ""
-
-#: templates/_snippets/key.html:5
-#: templates/submission/form-core.html:39
-msgid "No"
-msgstr ""
-
-#: templates/_snippets/key.html:6
-#: templates/submission/form-core.html:40
-msgid "Unsure"
-msgstr ""
-
-#: templates/_snippets/key.html:7
-msgid "No data"
-msgstr ""
-
-#: templates/_snippets/missing_place_button.html:3
-msgid "Add new location"
-msgstr ""
-
-#: templates/_snippets/questions.html:4
-msgid "Question"
-msgstr ""
-
-#: templates/_snippets/questions.html:6
-msgid "Weighting"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:3
-msgid "Review"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:7
-msgid "Actions"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:8
-msgid "Please add a short comment as to why you are accepting or rejecting this submission. **Note that your message will be publicly visible**."
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:10
-msgid "Publish"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:11
-msgid "Reject"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:15
-msgid "Important"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:17
-msgid "As the reviewer, your name **(%(name)s)** will be logged and displayed with the entry"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:18
-msgid "If this submission makes no changes to the current entry then please 'Reject' it rather than 'Accept'"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:19
-msgid "Note that you edit the submission before accepting it. In particular, please correct any spelling mistakes"
-msgstr ""
-
-#: templates/_snippets/reviewer_actions.html:20
-msgid "Publish will overwrite the whole current entry with the data in this form"
-msgstr ""
-
-#: templates/_snippets/share_page_buttons.html:1
-#: templates/_snippets/share_submission_buttons.html:5
-msgid "Share on Twitter"
-msgstr ""
-
-#: templates/_snippets/share_page_buttons.html:4
-#: templates/_snippets/share_submission_buttons.html:10
-msgid "Share on Facebook"
-msgstr ""
-
-#: templates/_snippets/share_page_buttons.html:7
-#: templates/_snippets/share_submission_buttons.html:14
-msgid "Share on Google+"
-msgstr ""
-
-#: templates/_snippets/share_submission_buttons.html:6
-msgid "Twitter"
-msgstr ""
-
-#: templates/_snippets/share_submission_buttons.html:11
-msgid "Facebook"
-msgstr ""
-
-#: templates/_snippets/share_submission_buttons.html:15
-msgid "Google+"
-msgstr ""
-
-#: templates/country/dataset.html:5
-#: templates/country/dataset.html:12
-msgid "Datasets"
-msgstr ""
-
-#: templates/country/dataset.html:25
-msgid "On this page you can see the state of open data for %(dataset)s in all the places for which we have information."
-msgstr ""
-
-#: templates/country/dataset.html:28
-msgid "Dataset Description"
-msgstr ""
-
-#: templates/country/dataset.html:43
-#: templates/submission/create.html:37
-msgid "Place"
-msgstr ""
-
-#: templates/country/dataset.html:44
-#: templates/country/place.html:40
-msgid "Score"
-msgstr ""
-
-#: templates/country/dataset.html:45
-#: templates/country/place.html:41
-msgid "Breakdown"
-msgstr ""
-
-#: templates/country/dataset.html:46
-#: templates/country/place.html:43
-msgid "Location (URL)"
-msgstr ""
-
-#: templates/country/dataset.html:47
-#: templates/country/place.html:44
-#: templates/submission/form-core.html:42
-msgid "Information"
-msgstr ""
-
-#: templates/country/dataset.html:64
-#: templates/country/place.html:70
-msgid "Propose Revisions"
-msgstr ""
-
-#: templates/country/dataset.html:66
-#: templates/country/place.html:74
-msgid "Submit information"
-msgstr ""
-
-#: templates/country/entry.html:4
-msgid "Entry for %(place)s / %(title)s"
-msgstr ""
-
-#: templates/country/entry.html:11
-msgid "Return to dataset overview"
-msgstr ""
-
-#: templates/country/entry.html:24
-msgid "Data Location"
-msgstr ""
-
-#: templates/country/entry.html:27
-#: templates/submission/review.html:79
-msgid "Comments"
-msgstr ""
-
-#: templates/country/entry.html:30
-msgid "Data Availability"
-msgstr ""
-
-#: templates/country/entry.html:59
-msgid "Date the data became available"
-msgstr ""
-
-#: templates/country/entry.html:59
-#: templates/country/entry.html:60
-#: templates/country/entry.html:62
-msgid "Unknown"
-msgstr ""
-
-#: templates/country/entry.html:60
-msgid "Format of data"
-msgstr ""
-
-#: templates/country/entry.html:61
-#: templates/country/place.html:119
-msgid "Contributors"
-msgstr ""
-
-#: templates/country/entry.html:61
-msgid "(Editors)"
-msgstr ""
-
-#: templates/country/entry.html:61
-msgid "(Submitters)"
-msgstr ""
-
-#: templates/country/entry.html:62
-msgid "Last modified"
-msgstr ""
-
-#: templates/country/place.html:5
-#: templates/country/place.html:12
-msgid "Places"
-msgstr ""
-
-#: templates/country/place.html:25
-msgid "This is the overview page where you can see the state of open data across each key dataset."
-msgstr ""
-
-#: templates/country/place.html:84
-msgid "&#8627; Awaiting review"
-msgstr ""
-
-#: templates/country/place.html:86
+#: views/changes.html:42
+#: views/includes/dataviews/table_places.html:79
+#: views/includes/dataviews/table_slice_dataset.html:64
+#: views/includes/dataviews/table_slice_dataset.html:101
+#: views/includes/dataviews/table_slice_dataset.html:130
+#: views/includes/dataviews/table_slice_place.html:63
+#: views/includes/dataviews/table_slice_place.html:98
+#: views/includes/dataviews/table_slice_place.html:127
 msgid "Submitted by"
 msgstr ""
 
-#: templates/country/place.html:91
-msgid "Submitted on"
+#: views/changes.html:51
+#: views/includes/dataviews/table_places.html:79
+#: views/includes/dataviews/table_slice_dataset.html:64
+#: views/includes/dataviews/table_slice_place.html:63
+msgid "and reviewed by"
 msgstr ""
 
-#: templates/country/place.html:99
-msgid "View Submission"
-msgstr ""
-
-#: templates/country/place.html:106
-msgid "Sorry, only one submission can be waiting for review at a time - please come back in a few days to submit new information"
-msgstr ""
-
-#: templates/country/place.html:120
-msgid "Editors for %(name)s:"
-msgstr ""
-
-#: templates/country/place.html:124
-msgid "With submissions from:"
-msgstr ""
-
-#: templates/submission/create.html:4
-#: templates/submission/create.html:78
+#: views/create.html:4
 msgid "Submit"
 msgstr ""
 
-#: templates/submission/create.html:9
-msgid "Make a Submission &ndash; %(sitename)s"
+#: views/create.html:17
+msgid "Select a Place"
 msgstr ""
 
-#: templates/submission/create.html:15
-msgid "The form has missing or incorrect data"
+#: views/create.html:19
+msgid "change place"
 msgstr ""
 
-#: templates/submission/create.html:34
-msgid "Place and Dataset"
+#: views/create.html:30
+msgid "Select a Dataset"
 msgstr ""
 
-#: templates/submission/create.html:39
-#: templates/submission/create.html:49
-msgid "Please select"
+#: views/create.html:32
+msgid "change dataset"
 msgstr ""
 
-#: templates/submission/create.html:65
-msgid "%(sitename)s Year"
-msgstr ""
-
-#: templates/submission/create.html:74
-msgid "Your Name &ndash; %(name)s"
-msgstr ""
-
-#: templates/submission/create.html:75
-msgid "This will be public."
-msgstr ""
-
-#: templates/submission/create.html:79
-msgid "By submitting material to the index you agreeing to <a href=\"http://okfn.org/terms-of-use/\">terms of use</a> and also to license your contribution (to the extent there are any rights in it!) under the <a href=\"http://opendatacommons.org/licenses/pddl/1.0/\">Open Data Commons Public Domain Dedication and License</a>."
-msgstr ""
-
-#: templates/submission/form-core.html:3
-msgid "Current Entry"
-msgstr ""
-
-#: templates/submission/form-core.html:9
-#: templates/submission/form-core.html:12
-#: templates/submission/form-core.html:57
-msgid "No entry"
-msgstr ""
-
-#: templates/submission/form-core.html:41
-msgid "Current"
-msgstr ""
-
-#: templates/submission/form-core.html:90
-msgid "Preview"
-msgstr ""
-
-#: templates/submission/review.html:4
-msgid "Review Submission"
-msgstr ""
-
-#: templates/submission/review.html:16
-msgid "If you are a reviewer, please login to review"
-msgstr ""
-
-#: templates/submission/review.html:44
+#: views/create.html:48
 msgid "Status"
 msgstr ""
 
-#: templates/submission/review.html:45
+#: views/create.html:50
 msgid "Submission date"
 msgstr ""
 
-#: templates/submission/review.html:46
+#: views/create.html:54
 msgid "Submitter"
 msgstr ""
 
-#: templates/submission/review.html:48
+#: views/create.html:59
+#: views/entry.html:157
 msgid "Reviewer"
 msgstr ""
 
-#: templates/submission/review.html:49
-msgid "Review comments"
+#: views/create.html:75
+msgid "You do not have permissions to review this submission."
+msgstr ""
+
+#: views/create.html:85
+msgid "If you are a reviewer, please login to review."
+msgstr ""
+
+#: views/create.html:96
+msgid "The form has missing or incorrect data"
+msgstr ""
+
+#: views/create.html:99
+msgid "Current is '%s'"
+msgstr ""
+
+#: views/create.html:114
+msgid "Please read the <a class=\"btn btn-sm\" data-toggle=\"modal\" data-target=\"#guidance\">{% if isReview %}Review{% else %}Submission{% endif %} Guidance</a> before proceeding."
+msgstr ""
+
+#: views/create.html:124
+msgid "{% if isReview %}Review{% else %}Submission{% endif %} Guidance"
+msgstr ""
+
+#: views/create.html:130
+msgid "Got it"
+msgstr ""
+
+#: views/dataset.html:11
+#: views/place.html:11
+msgid "%(score)s% open (avg.)"
+msgstr ""
+
+#: views/dataset.html:15
+msgid "Ranked #1 against other datasets in the Index (avg.)"
+msgstr ""
+
+#: views/dataset.html:30
+#: views/entry.html:29
+#: views/overview.html:57
+#: views/place.html:32
+msgid "See other years"
+msgstr ""
+
+#: views/entry.html:15
+msgid "%(score)s% open"
+msgstr ""
+
+#: views/entry.html:61
+msgid "What data is expected?"
+msgstr ""
+
+#: views/entry.html:67
+msgid "What data is available?"
+msgstr ""
+
+#: views/entry.html:107
+msgid "Details"
+msgstr ""
+
+#: views/entry.html:113
+msgid "Reviewer comments"
+msgstr ""
+
+#: views/entry.html:123
+msgid "Contributors"
+msgstr ""
+
+#: views/entry.html:127
+msgid "Reviewers"
+msgstr ""
+
+#: views/entry.html:136
+#: views/entry.html:158
+msgid "Submitters"
+msgstr ""
+
+#: views/entry.html:152
+msgid "Meta data"
+msgstr ""
+
+#: views/entry.html:155
+msgid "Date the data became available"
+msgstr ""
+
+#: views/entry.html:155
+#: views/entry.html:156
+#: views/entry.html:159
+msgid "Unknown"
+msgstr ""
+
+#: views/entry.html:156
+msgid "Format of data"
+msgstr ""
+
+#: views/entry.html:159
+msgid "Last modified"
+msgstr ""
+
+#: views/login.html:15
+msgid "Please login to contribute to the Census."
+msgstr ""
+
+#: views/login.html:21
+msgid "Login with Google &raquo;"
+msgstr ""
+
+#: views/login.html:24
+msgid "Login with Facebook &raquo;"
+msgstr ""
+
+#: views/login.html:32
+msgid "Login with your existing 3rd party account in a few seconds. We will not share your email with any third party. For more information see the"
+msgstr ""
+
+#: views/login.html:32
+msgid "terms of use"
+msgstr ""
+
+#: views/overview.html:17
+msgid "Number of places"
+msgstr ""
+
+#: views/overview.html:23
+msgid "Number of datasets"
+msgstr ""
+
+#: views/overview.html:29
+msgid "Number of open datasets"
+msgstr ""
+
+#: views/overview.html:35
+msgid "Percentage <a href='%s'>open</a>"
+msgstr ""
+
+#: views/overview.html:48
+msgid "Search"
+msgstr ""
+
+#: views/overview.html:66
+#: views/includes/share_buttons.html:1
+msgid "Share this page"
+msgstr ""
+
+#: views/overview.html:81
+#: views/overview.html:99
+#: views/includes/share_buttons.html:17
+#: views/includes/share_buttons.html:30
+msgid "Close"
+msgstr ""
+
+#: views/overview.html:82
+#: views/includes/share_buttons.html:18
+msgid "Map embed code"
+msgstr ""
+
+#: views/overview.html:86
+#: views/includes/share_buttons.html:21
+msgid "Use the following code to embed the map visualisation into your own website."
+msgstr ""
+
+#: views/overview.html:94
+#: views/includes/share_buttons.html:23
+msgid "If you are a developer, you can read more about the embed options here:"
+msgstr ""
+
+#: views/overview.html:95
+#: views/includes/share_buttons.html:24
+#: views/includes/share_buttons.html:25
+msgid "Embed options"
+msgstr ""
+
+#: views/place.html:10
+msgid "See more data on %(name)s in the Open Data Index"
+msgstr ""
+
+#: views/place.html:15
+msgid "Ranked #1 against other places in the Index (avg.)"
+msgstr ""
+
+#: views/test.html:3
+msgid "hello"
+msgstr ""
+
+#: views/test.html:5
+msgid "that"
+msgstr ""
+
+#: views/test.html:7
+msgid "Submitted by %s and reviewed by %s"
+msgstr ""
+
+#: views/includes/godi-home.html:3
+msgid "Tracking the state of government open data."
+msgstr ""
+
+#: views/includes/godi-home.html:5
+msgid "The first initiative of its kind, the Global Open Data Index provides the most comprehensive snapshot available of the global state of open data."
+msgstr ""
+
+#: views/includes/godi-home.html:8
+msgid "Compare countries"
+msgstr ""
+
+#: views/includes/godi-home.html:12
+msgid "See insights"
+msgstr ""
+
+#: views/includes/share_buttons.html:4
+msgid "Embed"
+msgstr ""
+
+#: views/macros/popovers.html:16
+msgid "There is no data available."
+msgstr ""
+
+#: views/macros/popovers.html:37
+msgid "Read more &raquo;"
+msgstr ""
+
+#: views/includes/dataviews/table_places.html:7
+msgid "Sort by Rank"
+msgstr ""
+
+#: views/includes/dataviews/table_places.html:7
+#: views/includes/dataviews/table_slice_dataset.html:25
+msgid "Rank"
+msgstr ""
+
+#: views/includes/dataviews/table_places.html:8
+msgid "Sort by A-Z"
+msgstr ""
+
+#: views/includes/dataviews/table_places.html:8
+#: views/includes/dataviews/table_slice_dataset.html:26
+msgid "Place"
+msgstr ""
+
+#: views/includes/dataviews/table_places.html:14
+#: views/includes/dataviews/table_slice_dataset.html:32
+#: views/includes/dataviews/table_slice_place.html:29
+msgid "Score"
+msgstr ""
+
+#: views/includes/dataviews/table_places.html:64
+msgid "No data"
+msgstr ""
+
+#: views/includes/dataviews/table_places.html:82
+#: views/includes/dataviews/table_places.html:89
+#: views/includes/dataviews/table_places.html:91
+msgid "Pending submissions"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:27
+#: views/includes/dataviews/table_slice_place.html:24
+msgid "Breakdown"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:28
+#: views/includes/dataviews/table_slice_place.html:25
+msgid "Info"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:30
+#: views/includes/dataviews/table_slice_place.html:27
+msgid "Year"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:34
+#: views/includes/dataviews/table_slice_place.html:31
+msgid "Admin"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:74
+#: views/includes/dataviews/table_slice_place.html:73
+msgid "Sorry, only one submission can be waiting for review at a time - please come back in a few days to submit new information"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:76
+#: views/includes/dataviews/table_slice_place.html:75
+msgid "Propose Revisions"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:100
+#: views/includes/dataviews/table_slice_place.html:97
+msgid "Awaiting review"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:106
+#: views/includes/dataviews/table_slice_place.html:103
+msgid "Submitted on"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_dataset.html:137
+#: views/includes/dataviews/table_slice_place.html:134
+msgid "View Submission"
+msgstr ""
+
+#: views/includes/dataviews/table_slice_place.html:23
+msgid "Dataset"
 msgstr ""

--- a/census/locale/templates/LC_MESSAGES/messages.pot
+++ b/census/locale/templates/LC_MESSAGES/messages.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-08T15:23:40.826Z\n"
+"POT-Creation-Date: 2016-12-08T17:28:19.317Z\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language: \n"
@@ -216,15 +216,23 @@ msgstr ""
 msgid "Current is '%s'"
 msgstr ""
 
-#: views/create.html:114
-msgid "Please read the <a class=\"btn btn-sm\" data-toggle=\"modal\" data-target=\"#guidance\">{% if isReview %}Review{% else %}Submission{% endif %} Guidance</a> before proceeding."
+#: views/create.html:115
+msgid "Please read the <a class=\"btn btn-sm\" data-toggle=\"modal\" data-target=\"#guidance\">Review Guidance</a> before proceeding."
 msgstr ""
 
-#: views/create.html:124
-msgid "{% if isReview %}Review{% else %}Submission{% endif %} Guidance"
+#: views/create.html:117
+msgid "Please read the <a class=\"btn btn-sm\" data-toggle=\"modal\" data-target=\"#guidance\">Submission Guidance</a> before proceeding."
 msgstr ""
 
-#: views/create.html:130
+#: views/create.html:128
+msgid "Review Guidance"
+msgstr ""
+
+#: views/create.html:128
+msgid "Submission Guidance"
+msgstr ""
+
+#: views/create.html:134
 msgid "Got it"
 msgstr ""
 

--- a/census/locale/templates/LC_MESSAGES/messages.pot
+++ b/census/locale/templates/LC_MESSAGES/messages.pot
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-08T17:28:19.317Z\n"
+"POT-Creation-Date: 2016-12-08T17:37:16.220Z\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language: \n"
@@ -236,6 +236,22 @@ msgstr ""
 msgid "Got it"
 msgstr ""
 
+#: views/dataset.html:11
+#: views/place.html:11
+msgid "%(score)s% open (avg.)"
+msgstr ""
+
+#: views/dataset.html:15
+msgid "Ranked #1 against other datasets in the Index (avg.)"
+msgstr ""
+
+#: views/dataset.html:30
+#: views/entry.html:29
+#: views/overview.html:57
+#: views/place.html:32
+msgid "See other years"
+msgstr ""
+
 #: controllers/census.js:83
 msgid "Make a Submission"
 msgstr ""
@@ -286,22 +302,6 @@ msgstr ""
 
 #: controllers/census.js:436
 msgid "Submission marked as rejected."
-msgstr ""
-
-#: views/dataset.html:11
-#: views/place.html:11
-msgid "%(score)s% open (avg.)"
-msgstr ""
-
-#: views/dataset.html:15
-msgid "Ranked #1 against other datasets in the Index (avg.)"
-msgstr ""
-
-#: views/dataset.html:30
-#: views/entry.html:29
-#: views/overview.html:57
-#: views/place.html:32
-msgid "See other years"
 msgstr ""
 
 #: views/entry.html:15
@@ -474,6 +474,14 @@ msgstr ""
 msgid "Ranked #1 against other places in the Index (avg.)"
 msgstr ""
 
+#: views/macros/popovers.html:16
+msgid "There is no data available."
+msgstr ""
+
+#: views/macros/popovers.html:37
+msgid "Read more &raquo;"
+msgstr ""
+
 #: views/includes/godi-home.html:3
 msgid "Tracking the state of government open data."
 msgstr ""
@@ -492,14 +500,6 @@ msgstr ""
 
 #: views/includes/share_buttons.html:4
 msgid "Embed"
-msgstr ""
-
-#: views/macros/popovers.html:16
-msgid "There is no data available."
-msgstr ""
-
-#: views/macros/popovers.html:37
-msgid "Read more &raquo;"
 msgstr ""
 
 #: views/includes/dataviews/table_places.html:7

--- a/census/middlewares/index.js
+++ b/census/middlewares/index.js
@@ -12,8 +12,8 @@ var internalServerError = function(err, req, res, next) {
   console.error(err.stack);
   res.status(500)
     .render('500.html', {
-      title: req.gettext('500: Internal Server Error'),
-      message: req.gettext('Something is up with the server.<br />') + err
+      title: '500: Internal Server Error',
+      message: 'Something is up with the server.<br />' + err
     });
 };
 

--- a/census/middlewares/index.js
+++ b/census/middlewares/index.js
@@ -3,8 +3,8 @@
 var notFound = function(req, res, next) {
   res.status(404)
     .render('404.html', {
-      title: '404: Not Found',
-      message: 'Nothing here!'
+      title: req.gettext('404: Not Found'),
+      message: req.gettext('Nothing here!')
     });
 };
 
@@ -12,8 +12,8 @@ var internalServerError = function(err, req, res, next) {
   console.error(err.stack);
   res.status(500)
     .render('500.html', {
-      title: '500: Internal Server Error',
-      message: 'Something is up with the server.<br />' + err
+      title: req.gettext('500: Internal Server Error'),
+      message: req.gettext('Something is up with the server.<br />') + err
     });
 };
 

--- a/census/views/base.html
+++ b/census/views/base.html
@@ -44,13 +44,13 @@
           {% endif %}
           <div>
             <a class="title" href="/" title="{{ gettext('Home')}}">{{ site.settings.title }}</a>
-            <span class="tagline">Powered by <a href="http://census.okfn.org">Open Data Census</a></span>
+            <span class="tagline">{{ format(gettext("Powered by <a href='%s'>Open Data Census</a>"), ['http://census.okfn.org']) }}</span>
           </div>
         </div>
         {% endif %}
 
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav">
-          <span class="sr-only">Toggle navigation</span>
+          <span class="sr-only">{{ gettext("Toggle navigation") }}</span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -122,12 +122,12 @@
           <img src="https://a.okfn.org/img/oki/landscape-white-468x122.png" alt="Open Knowledge International">
           </a>
           <ul class="footer-links">
-            <li><a href="https://okfn.org/privacy-policy/">Privacy policy</a></li>
-            <li><a href="https://okfn.org/ip-policy/">IP policy</a></li>
-            <li><a href="https://okfn.org/cookie-policy/">Cookie policy</a></li>
-            <li><a href="https://okfn.org/terms-of-use/">Terms of use</a></li>
-            <li><a href="http://okfn.org/opendata/" title="More about Open Data">What is Open Data</a></li>
-            <li><a href="http://meta.census.okfn.org/">Run Your Own Local Open Data Census</a></li>
+            <li><a href="https://okfn.org/privacy-policy/">{{ gettext("Privacy policy") }}</a></li>
+            <li><a href="https://okfn.org/ip-policy/">{{ gettext("IP policy") }}</a></li>
+            <li><a href="https://okfn.org/cookie-policy/">{{ gettext("Cookie policy") }}</a></li>
+            <li><a href="https://okfn.org/terms-of-use/">{{ gettext("Terms of use") }}</a></li>
+            <li><a href="http://okfn.org/opendata/" title="More about Open Data">{{ gettext("What is Open Data") }}</a></li>
+            <li><a href="http://meta.census.okfn.org/">{{ gettext("Run Your Own Local Open Data Census") }}</a></li>
           </ul>
         </div>
         {% if site.settings.custom_footer %}
@@ -143,7 +143,7 @@
             <a href="/api/entries.json">{{ gettext("All (JSON)") }}</a>
           </p>
           <p>
-            <a href="http://opendatacommons.org/licenses/pddl/1.0">Data License (Public Domain)</a>. <a href="https://github.com/okfn/opendatacensus/">Source code</a>.
+            <a href="http://opendatacommons.org/licenses/pddl/1.0">{{ gettext("Data License (Public Domain)") }}</a>. <a href="https://github.com/okfn/opendatacensus/">{{ gettext("Source code") }}</a>.
           </p>
         </div>
         <span class="glyphicon glyphicon-user" aria-hidden="true"></span>

--- a/census/views/base.html
+++ b/census/views/base.html
@@ -1,7 +1,7 @@
 {% set is_index = site.settings.is_index or false %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}" dir="{{ lang_dir }}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/census/views/changes.html
+++ b/census/views/changes.html
@@ -1,12 +1,12 @@
 {% extends "page.html" %}
 
 {% block title %}
-{{gettext("Recent Changes")}}
+{{ gettext("Recent Changes") }}
 {% endblock %}
 
 {% block content %}
 <div class="container">
-  <h1>{{gettext("Changelog")}}</h1>
+  <h1>{{ gettext("Changelog")}} </h1>
   <p>
     {{ gettext("A log of the most recent submission and entry activity.") }}
   </p>

--- a/census/views/create.html
+++ b/census/views/create.html
@@ -111,7 +111,11 @@
   <div class="container">
     <div>
       <p>
-        {{ gettext('Please read the <a class="btn btn-sm" data-toggle="modal" data-target="#guidance">{% if isReview %}Review{% else %}Submission{% endif %} Guidance</a> before proceeding.') }}
+        {% if isReview %}
+          {{ gettext('Please read the <a class="btn btn-sm" data-toggle="modal" data-target="#guidance">Review Guidance</a> before proceeding.') }}
+        {% else %}
+          {{ gettext('Please read the <a class="btn btn-sm" data-toggle="modal" data-target="#guidance">Submission Guidance</a> before proceeding.') }}
+        {% endif %}
       </p>
     </div>
   </div>
@@ -121,7 +125,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="myModalLabel">{{ gettext("{% if isReview %}Review{% else %}Submission{% endif %} Guidance") }}</h4>
+        <h4 class="modal-title" id="myModalLabel">{% if isReview %}{{ gettext('Review Guidance') }}{% else %}{{ gettext('Submission Guidance') }}{% endif %}</h4>
       </div>
       <div class="modal-body">
         {{ submitInstructions }}

--- a/census/views/create.html
+++ b/census/views/create.html
@@ -14,9 +14,9 @@
       <div class="primary-meta">
         <h1>
           <span class="no-js place">
-            {{ placeName or 'Select a Place' }}
+            {{ placeName or gettext('Select a Place') }}
             {% if not isReview %}
-            <a href="#"><span>(change place)</span></a>
+            <a href="#"><span>({{ gettext("change place") }})</span></a>
             <span>
               <ul>
                 {% for place in places -%}
@@ -27,9 +27,9 @@
             {% endif %}
           </span>
           <span class="no-js dataset">
-            {{ datasetName or 'Select a Dataset'}}
+            {{ datasetName or gettext('Select a Dataset')}}
             {% if not isReview %}
-            <a href="#"><span>(change dataset)</span></a>
+            <a href="#"><span>({{ gettext("change dataset") }})</span></a>
             <span>
               <ul>
                 {% for dataset in datasets -%}
@@ -45,18 +45,18 @@
       {% if isReview -%}
         <div class="secondary-meta">
           <dl class="{{ entryStatus }}">
-            <dt class="status">Status</dt>
+            <dt class="status">{{ gettext("Status") }}</dt>
             <dd>{{ entryStatus }}</dd>
-            <dt class="date">Submission date</dt>
+            <dt class="date">{{ gettext("Submission date") }}</dt>
             <dd>
               <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> {{ entry.createdAt|dateformat }}
             </dd>
-            <dt class="submitter">Submitter</dt>
+            <dt class="submitter">{{ gettext("Submitter") }}</dt>
             <dd>
               <span class="glyphicon glyphicon-user" aria-hidden="true"></span> {% if entry.Submitter %}{% if entry.Submitter.isAnonymous() %}{{ entry.Submitter.firstName|title }}{% else %}{{ entry.Submitter.fullName() }}{% endif %}{% endif %}
             </dd>
             {% if entry.Reviewer %}
-             <dt>Reviewer</dt>
+             <dt>{{ gettext("Reviewer") }}</dt>
              <dd><span class="glyphicon glyphicon-user" aria-hidden="true"></span> {% if entry.Reviewer %}{% if entry.Reviewer.isAnonymous() %}{{ entry.Reviewer.firstName|title }}{% else %}{{ entry.Reviewer.fullName() }}{% endif %}{% endif %}</dd>
             {% endif %}
           </dl>
@@ -82,7 +82,7 @@
     <div class="alert alert-warning" role="alert">
       <div class="container">
         <div>
-          <p>{{gettext("If you are a reviewer, please login to review.")}} <a class="btn btn-primary" href="{{ loginUrl }}?next=census/submission/{{ entry.id }}">{{gettext("Login")}}</a></p>
+          <p>{{ gettext("If you are a reviewer, please login to review.") }} <a class="btn btn-primary" href="{{ loginUrl }}?next=census/submission/{{ entry.id }}">{{ gettext("Login") }}</a></p>
         </div>
       </div>
     </div>
@@ -96,7 +96,7 @@
       <p>{{ gettext("The form has missing or incorrect data")}}:</p>
       <ul>
       {% for error in errors %}
-        <li>{{ error.param }}: {{ error.msg }} {% if error.value %}(Current is '{{ error.value }}'){% endif %}</li>
+        <li>{{ error.param }}: {{ error.msg }} {% if error.value %}({{ format(gettext("Current is '%s'"), [error.value]) }}){% endif %}</li>
       {% endfor %}
       </ul>
     </div>
@@ -111,7 +111,7 @@
   <div class="container">
     <div>
       <p>
-        Please read the <a class="btn btn-sm" data-toggle="modal" data-target="#guidance">{% if isReview %}Review{% else %}Submission{% endif %} Guidance</a> before proceeding.
+        {{ gettext('Please read the <a class="btn btn-sm" data-toggle="modal" data-target="#guidance">{% if isReview %}Review{% else %}Submission{% endif %} Guidance</a> before proceeding.') }}
       </p>
     </div>
   </div>
@@ -121,13 +121,13 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="myModalLabel">{% if isReview %}Review{% else %}Submission{% endif %} Guidance</h4>
+        <h4 class="modal-title" id="myModalLabel">{{ gettext("{% if isReview %}Review{% else %}Submission{% endif %} Guidance") }}</h4>
       </div>
       <div class="modal-body">
         {{ submitInstructions }}
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Got it</button>
+        <button type="button" class="btn btn-default" data-dismiss="modal">{{ gettext("Got it") }}</button>
       </div>
     </div>
   </div>

--- a/census/views/dataset.html
+++ b/census/views/dataset.html
@@ -8,7 +8,7 @@
       <div class="col-md-{% if is_index %}6{% else %}12{% endif %}">
         <h1>
           <a href="http://index.okfn.org/dataset/{{ dataset.id }}/" title="{{ format("See more data on %(name)s in the Open Data Index", {name: dataset.name}) }}">{{ dataset.name }}</a>
-          <span style="background-color: rgb(223, 204, 51); color: white;" class="dataset-openness" data-score="{{ stats.openDataPercent }}">{{ format("%(score)s% open (avg.)", {score: stats.openDataPercent}) }}</span>
+          <span style="background-color: rgb(223, 204, 51); color: white;" class="dataset-openness" data-score="{{ stats.openDataPercent }}">{{ format(gettext("%(score)s% open (avg.)"), {score: stats.openDataPercent}) }}</span>
         </h1>
         {% if is_index == "true" -%}
           <div class="col-md-12 place-rank statistics">

--- a/census/views/entry.html
+++ b/census/views/entry.html
@@ -12,7 +12,7 @@
       <div class="col-md-{% if is_index %}6{% else %}12{% endif %}">
       <h1>
         <a href="http://index.okfn.org/dataset/{{ dataset.id }}/" title="{{ format("See more data on %(name)s in the Open Data Index", {name: dataset.name}) }}">{{ dataset.name }}</a>
-        <span class="place-openness" data-score="{{ computedRelativeScore }}" style="background-color: rgb(122, 184, 0); color: white;">{{ format("%(score)s% open", {score: computedRelativeScore}) }}</span>
+        <span class="place-openness" data-score="{{ computedRelativeScore }}" style="background-color: rgb(122, 184, 0); color: white;">{{ format(gettext("%(score)s% open"), {score: computedRelativeScore}) }}</span>
       </h1>
       <h3>
         <a href="http://index.okfn.org/place/{{ place.id }}{{ urlContext }}" title="{{ format("See more data on %(name)s in the Open Data Index", {name: place.name}) }}">{{ place.name }}</a>
@@ -156,7 +156,7 @@
       <tr><td>{{ gettext("Format of data") }}</td><td>&nbsp;&nbsp;&nbsp;{% if entry.answers.format %}{{ entry.answers.format }}{% else %}{{ gettext("Unknown") }}{% endif %}</td></tr>
       <tr><td>{{ gettext("Reviewer") }}</td><td>&nbsp;&nbsp;&nbsp;{% if entry.Reviewer %}{{entry.Reviewer.fullName()}}{% endif %}</td></tr>
       <tr><td>{{ gettext("Submitters") }}</td><td>&nbsp;&nbsp;&nbsp;{% if entry.Submitter %}{{entry.Submitter.fullName()}}{% endif %}</td></tr>
-      <tr><td>{{ gettext("Last modified") }}</td><td>&nbsp;&nbsp;&nbsp;{% if entry.createdAt %}{{ entry.createdAt }}{% else %}{{gettext("Unknown")}}{% endif %}</td></tr>
+      <tr><td>{{ gettext("Last modified") }}</td><td>&nbsp;&nbsp;&nbsp;{% if entry.createdAt %}{{ entry.createdAt }}{% else %}{{ gettext("Unknown") }}{% endif %}</td></tr>
       </tbody>
     </table>
   </div>

--- a/census/views/includes/dataviews/table_slice_dataset.html
+++ b/census/views/includes/dataviews/table_slice_dataset.html
@@ -22,16 +22,16 @@
 
         <thead class="" style="">
           <tr>
-            <th class="clickable">Rank</th>
-            <th class="clickable">Place</th>
-            <th>Breakdown</th>
-            <th>Info</th>
+            <th class="clickable">{{ gettext("Rank") }}</th>
+            <th class="clickable">{{ gettext("Place") }}</th>
+            <th>{{ gettext("Breakdown") }}</th>
+            <th>{{ gettext("Info") }}</th>
             {% if not is_index %}
-            <th>Year</th>
+            <th>{{ gettext("Year") }}</th>
             {% endif %}
-            <th class="clickable">Score</th>
+            <th class="clickable">{{ gettext("Score") }}</th>
             {% if not is_index %}
-            <th class="admin"><span class="sr-only">Admin</span></th>
+            <th class="admin"><span class="sr-only">{{ gettext("Admin") }}</span></th>
             {% endif %}
           </tr>
         </thead>
@@ -97,7 +97,7 @@
               <td class="rank">{{place.rank}}</td>
               <td class="queued-context">
                 <span style="visibility: hidden;">{{ place.name }}</span>
-                <h6><span class="icon">&#8627;</span> Awaiting review</h6>
+                <h6><span class="icon">&#8627;</span> {{ gettext("Awaiting review") }}</h6>
                 <span title="{{ gettext('Submitted by')}} {{ submission.Submitter.firstName}}" class="queued-user">
                   <span class="glyphicon glyphicon-user" aria-hidden="true"></span>&nbsp;
                   {{ submission.Submitter.firstName }}

--- a/census/views/includes/dataviews/table_slice_place.html
+++ b/census/views/includes/dataviews/table_slice_place.html
@@ -20,15 +20,15 @@
 
         <thead class="" style="">
           <tr>
-            <th class="clickable">Dataset</th>
-            <th>Breakdown</th>
-            <th>Info</th>
+            <th class="clickable">{{ gettext("Dataset") }}</th>
+            <th>{{ gettext("Breakdown") }}</th>
+            <th>{{ gettext("Info") }}</th>
             {% if not is_index %}
-            <th>Year</th>
+            <th>{{ gettext("Year") }}</th>
             {% endif %}
-            <th class="clickable">Score</th>
+            <th class="clickable">{{ gettext("Score") }}</th>
             {% if not is_index %}
-            <th class="admin"><span class="sr-only">Admin</span></th>
+            <th class="admin"><span class="sr-only">{{ gettext("Admin") }}</span></th>
             {% endif %}
           </tr>
         </thead>
@@ -94,7 +94,7 @@
             <tr id="submission-{{dataset.id}}-{{loop.index}}" data-rank="{{entry.rank}}" data-score="{{submission.computedScore}}" data-place="{{place.name}}" class="queued submission submission-{{dataset.id}}">
               <td class="queued-context">
                 {# hack around tablesorter and our row toggler #}<span style="visibility: hidden;">{{ dataset.name }}</span>
-                <h6><span class="icon">&#8627;</span> Awaiting review</h6>
+                <h6><span class="icon">&#8627;</span> {{ gettext("Awaiting review") }}</h6>
                 <span title="{{ gettext('Submitted by')}} {{ submission.Submitter.firstName}}" class="queued-user">
                   <span class="glyphicon glyphicon-user" aria-hidden="true"></span>&nbsp;
                   {{ submission.Submitter.firstName }}

--- a/census/views/includes/godi-home.html
+++ b/census/views/includes/godi-home.html
@@ -1,15 +1,15 @@
 <section id="home-about">
   <div class="container">
-    <h1>Tracking the state of government open data.</h1>
+    <h1>{{ gettext("Tracking the state of government open data.") }}</h1>
       <p>
-        The first initiative of its kind, the Global Open Data Index provides the most comprehensive snapshot available of the global state of open data.
+        {{ gettext("The first initiative of its kind, the Global Open Data Index provides the most comprehensive snapshot available of the global state of open data.") }}
       </p>
       <a class="btn" href="{{ SITEURL }}/place/">
-        Compare countries
+        {{ gettext("Compare countries") }}
       </a>
 
       <a class="btn" href="{{ SITEURL }}/insights/">
-        See insights
+        {{ gettext("See insights") }}
       </a>
   </div>
 </section>

--- a/census/views/includes/share_buttons.html
+++ b/census/views/includes/share_buttons.html
@@ -14,7 +14,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">{{ gettext("Close") }}</span></button>
         <h4 class="modal-title" id="embedLabel">{{ gettext("Map embed code") }}</h4>
       </div>
       <div class="modal-body">

--- a/census/views/login.html
+++ b/census/views/login.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 
 {% block title %}
-  {{gettext("Login")}}
+  {{ gettext("Login") }}
 {% endblock %}
 
 {% block content %}
 
 <div class="container">
   <div class="page-header">
-    <h1>{{gettext("Login")}}</h1>
+    <h1>{{ gettext("Login") }}</h1>
   </div>
 
   <div class="row">
@@ -18,10 +18,10 @@
 
   <div class="row">
     <div class="col-md-2 col-md-offset-4">
-      <a class="btn btn-primary" href="{{ authBase }}/google">{{gettext("Login with Google &raquo;")}}</a>
+      <a class="btn btn-primary" href="{{ authBase }}/google">{{ gettext("Login with Google &raquo;") }}</a>
     </div>
     <div class="col-md-2">
-      <a class="btn btn-primary" href="{{ authBase }}/facebook">{{gettext("Login with Facebook &raquo;")}}</a>
+      <a class="btn btn-primary" href="{{ authBase }}/facebook">{{ gettext("Login with Facebook &raquo;") }}</a>
     </div>
   </div>
 
@@ -29,9 +29,7 @@
     <p>&nbsp;</p>
     <blockquote>
       <p>
-        {{gettext("Login with your existing 3rd party account in a few seconds. We will not share your email with any
-        third party. For more information see the")}}
-        <a href="https://okfn.org/terms-of-use/" title="{{ gettext(" terms of use") }}">{{ gettext("terms of use")}}</a>
+        {{ gettext("Login with your existing 3rd party account in a few seconds. We will not share your email with any third party. For more information see the") }} <a href="https://okfn.org/terms-of-use/" title="{{ gettext("terms of use") }}">{{ gettext("terms of use") }}</a>
         .
       </p>
     </blockquote>

--- a/census/views/macros/breadcrumb.html
+++ b/census/views/macros/breadcrumb.html
@@ -1,8 +1,8 @@
-{% macro breadcrumb(childTitle) %}
+{% macro breadcrumb(childTitle, gettext) %}
 <div class="breadcrumb-wrapper">
   <ol class="breadcrumb container">
     <li>
-        <a href="/">Home</a>
+        <a href="/">{{ gettext("Home") }}</a>
     </li>
     <li class="active">{{ childTitle }}</li>
   </ol>

--- a/census/views/macros/popovers.html
+++ b/census/views/macros/popovers.html
@@ -34,7 +34,7 @@
   {% if is_index != "true" -%}
     <div class='btn-group'>
     {% endif %}
-    <a class="btn btn-primary" href="/entry/{{ place.id }}/{{ dataset.id }}/">Read more &raquo;</a>
+    <a class="btn btn-primary" href="/entry/{{ place.id }}/{{ dataset.id }}/">{{ gettext("Read more &raquo;") }}</a>
     {% if is_index != "true" and submissionsAllowed %}
       <a class='btn btn-{{actionClass}}' href='{{actionUrl}}'>{{actionText}}</a>
     </div>

--- a/census/views/overview.html
+++ b/census/views/overview.html
@@ -14,25 +14,25 @@
   <ul class="summary featured">
     <li>
       <dl>
-        <dt>Number of places</dt>
+        <dt>{{ gettext("Number of places") }}</dt>
         <dd id="nc">{{ stats.placeCount }}</dd>
       </dl>
     </li>
     <li>
       <dl>
-        <dt>Number of datasets</dt>
+        <dt>{{ gettext("Number of datasets") }}</dt>
         <dd id="nds">{{ stats.currentEntryCount }}</dd>
       </dl>
     </li>
     <li>
       <dl>
-        <dt>Number of open datasets</dt>
+        <dt>{{ gettext("Number of open datasets") }}</dt>
         <dd id="nok">{{ stats.currentEntryOpenCount }}</dd>
       </dl>
     </li>
     <li>
       <dl>
-        <dt>Percentage <a href="http://okfn.org/opendata/">open</a></dt>
+        <dt>{{ format(gettext("Percentage <a href='%s'>open</a>"), ['http://okfn.org/opendata/']) }}</dt>
         <dd id="nokpercent">{{ stats.openDataPercent }}%</dd>
       </dl>
     </li>
@@ -45,7 +45,7 @@
   <div class="row">
 
     <div class="col-md-4">
-      <h5>Search</h5>
+      <h5>{{ gettext("Search") }}</h5>
       <form role="form" class="form-inline data-table-tools">
         <div class="form-group">
           <input class="form-control filter-table" type="search" name="filter-table" placeholder="Search for a place">
@@ -54,7 +54,7 @@
     </div>
 
     <div class="col-md-4">
-      <h5>See other years</h5>
+      <h5>{{ gettext("See other years") }}</h5>
       <div class="btn-group">
         <a class="btn btn-default" href="http://index.okfn.org/place/2013/" title="2013">2013</a>
         <a class="btn btn-default" href="http://index.okfn.org/place/2014/" title="2014">2014</a>
@@ -63,7 +63,7 @@
     </div>
 
     <div class="col-md-4">
-      <h5>Share this page</h5>
+      <h5>{{ gettext("Share this page") }}</h5>
       <div class="btn-group">
         <a href="http://twitter.com/share?url={{current_url}}&amp;text=Check out this data from the {{ site.settings.title }}"
            class="btn btn-default twitter" target="_blank"><i class="fa fa-twitter"></i> Twitter </a>
@@ -78,12 +78,12 @@
           <div class="modal-content">
             <div class="modal-header">
               <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span
-                  class="sr-only">Close</span></button>
-              <h4 class="modal-title" id="embedLabel">Map embed code</h4>
+                  class="sr-only">{{ gettext("Close") }}</span></button>
+              <h4 class="modal-title" id="embedLabel">{{ gettext("Map embed code") }}</h4>
             </div>
             <div class="modal-body">
               <p>
-                Use the following code to embed the map visualisation into your own website.
+                {{ gettext("Use the following code to embed the map visualisation into your own website.") }}
               </p>
               <xmp contenteditable="true">
                 <iframe width="100%" height="300px"
@@ -91,12 +91,12 @@
                         frameBorder="0"></iframe>
               </xmp>
               <p>
-                If you are a developer, you can read more about the embed options here: <a
-                  href="https://github.com/okfn/opendataindex/#choropleth-map" title="Embed options">Embed options</a>
+                {{ gettext("If you are a developer, you can read more about the embed options here:") }} <a
+                  href="https://github.com/okfn/opendataindex/#choropleth-map" title="Embed options">{{ gettext("Embed options") }}</a>
               </p>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              <button type="button" class="btn btn-default" data-dismiss="modal">{{ gettext("Close") }}</button>
             </div>
           </div>
         </div>

--- a/census/views/page.html
+++ b/census/views/page.html
@@ -8,7 +8,7 @@
 
 {% block breadcrumb %}
   {% if breadcrumbTitle %}
-    {{ breadcrumb(breadcrumbTitle) }}
+    {{ breadcrumb(breadcrumbTitle, gettext) }}
   {% endif %}
 {% endblock %}
 

--- a/census/views/place.html
+++ b/census/views/place.html
@@ -7,8 +7,8 @@
     <div class="row">
       <div class="col-md-{% if is_index %}6{% else %}12{% endif %}">
         <h1>
-          <a href="http://index.okfn.org/place/{{ dataset.id }}/" title="{{ format("See more data on %(name)s in the Open Data Index", {name: place.name}) }}">{{ dataset.name }}</a>
-          <span style="background-color: rgb(223, 204, 51); color: white;" class="dataset-openness" data-score="{{ stats.openDataPercent }}">{{ format("%(score)s% open (avg.)", {score: stats.openDataPercent}) }}</span>
+          <a href="http://index.okfn.org/place/{{ dataset.id }}/" title="{{ format(gettext("See more data on %(name)s in the Open Data Index"), {name: place.name}) }}">{{ dataset.name }}</a>
+          <span style="background-color: rgb(223, 204, 51); color: white;" class="dataset-openness" data-score="{{ stats.openDataPercent }}">{{ format(gettext("%(score)s% open (avg.)"), {score: stats.openDataPercent}) }}</span>
         </h1>
         {% if is_index == "true" %}
         <div class="col-md-12 place-rank statistics">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,6 @@ function pot() {
   }))
   // Restore all the files...
   .pipe(htmlFilter.restore)
-  .on('error', gutil.log)
   // ... and now filter just the js files
   .pipe(jsFilter)
   .pipe(gulpXgettext({
@@ -43,9 +42,16 @@ function pot() {
   }))
   // Restore all the files...
   .pipe(jsFilter.restore)
+  // Concat all into the 'messages.pot' file
+  .pipe(gulpConcatPo('messages.pot', {
+    headers: {
+      'POT-Creation-Date': new Date().toISOString(),
+      'Content-Transfer-Encoding': '8bit',
+      'Project-Id-Version': 'PACKAGE VERSION',
+      'Language-Team': 'LANGUAGE <LL@li.org>',
+      'Content-Type': 'text/plain; charset=utf-8'
+    }}))
   .on('error', gutil.log)
-  // ... concat all into the 'messages.pot' file
-  .pipe(gulpConcatPo('messages.pot'))
   .pipe(gulp.dest('census/locale/templates/LC_MESSAGES'));
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,13 @@
-var gulp = require('gulp');
-var gulpConcatPo = require('gulp-concat-po');
-var gulpXgettext = require('gulp-xgettext');
-var gulpReplace = require('gulp-replace');
-var gulpRename = require('gulp-rename');
-var gulpSass = require('gulp-ruby-sass');
-var gutil = require('gulp-util');
-var exec = require('child_process').exec;
+'use strict';
+
+const gulp = require('gulp');
+const gulpConcatPo = require('gulp-concat-po');
+const gulpXgettext = require('gulp-xgettext');
+const gulpReplace = require('gulp-replace');
+const gulpRename = require('gulp-rename');
+const gulpSass = require('gulp-ruby-sass');
+const gutil = require('gulp-util');
+const exec = require('child_process').exec;
 
 gulp.task('pot', pot);
 gulp.task('update-po', updatePo);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "xss": "^0.2.13"
   },
   "devDependencies": {
+    "babel-jsxgettext": "^0.2.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.1.0",
     "chalk": "^1.1.0",
@@ -74,6 +75,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-ruby-sass": "^2.1.0",
+    "gulp-util": "^3.0.7",
     "gulp-xgettext": "^0.5.0",
     "istanbul": "^1.1.0-alpha.1",
     "jsdom": "^9.4.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "execSync": "^1.0.2",
     "gulp": "^3.8.9",
     "gulp-concat-po": "^0.1.0",
+    "gulp-filter": "^4.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-ruby-sass": "^2.1.0",


### PR DESCRIPTION
This PR prepares the codebase for localization by:

- fixing POT generation within the gulp pipeline
- marking strings with `gettext` in templates
- marking strings with `gettext` in js files
- generating a new POT file

This partly addresses #844.