### PR TITLE
Fixes for Dataset translations

### DIFF
--- a/MigrationNotes.md
+++ b/MigrationNotes.md
@@ -10,6 +10,8 @@ Datasets also have a new `UpdateEvery` column. The value for each cell in this c
 
 The new Question Set config sheet is like the `Site` config. It has `key` and `value` columns. It expects a `questions` key, the value is the url the questions sheet, and a `question_set_schema` key, the value is the question set schema in json format (see the [Question Set Schema](#question-set-schema-json-format) section below).
 
+The Dataset property `Title` has been renamed `Name` in the spreadsheet, to reflect the database fieldname used once loaded, and allow translations to work. `Title` will continue to work as a fallback, but isn't translatable with `Title@LC`.
+
 ### Extra Question Config
 
 Some question types require extra configuration. For example, the `likert` question type has configuration to define the number of options, and description and value for each option. This will be used to setup the survey form. There is a column called 'Config' in the spreadsheet where a small snippet of json can be added. Below are example configurations for question types that require it:

--- a/census/controllers/mixins.js
+++ b/census/controllers/mixins.js
@@ -36,6 +36,7 @@ var setupLocalization = function(req, res, site) {
   }
   res.locals.locales = locales;
   res.locals.currentLocale = req.locale;
+  req.params.locale = req.locale;
 };
 
 var requireDomain = function(req, res, next) {

--- a/census/controllers/mixins.js
+++ b/census/controllers/mixins.js
@@ -36,7 +36,6 @@ var setupLocalization = function(req, res, site) {
   }
   res.locals.locales = locales;
   res.locals.currentLocale = req.locale;
-  req.params.locale = req.locale;
 };
 
 var requireDomain = function(req, res, next) {

--- a/census/controllers/pages.js
+++ b/census/controllers/pages.js
@@ -157,7 +157,6 @@ var dataset = function(req, res) {
       data.year = req.params.year;
       data.submissionsAllowed = req.params.year === req.app.get('year');
       data.breadcrumbTitle = data.dataset.name;
-
       return res.render('dataset.html', data);
     }).catch(console.trace.bind(console));
 };

--- a/census/controllers/utils.js
+++ b/census/controllers/utils.js
@@ -209,7 +209,7 @@ var datasetMapper = function(data, site) {
   return _.defaults({
     id: data.id.toLowerCase(),
     description: marked(data.description),
-    name: data.title,
+    name: data.name || data.title,
     order: data.order || 100,
     reviewers: reviewers,
     disableforyears: disableforyears,

--- a/census/models/mixins.js
+++ b/census/models/mixins.js
@@ -7,7 +7,7 @@ var translated = function(locale) {
   if (this.translations && this.translations[locale]) {
     localized = this.translations[locale];
     _.forEach(localized, (value, key, list) => {
-      if (this.get(key) !== undefined) {
+      if (value && this.get(key) !== undefined) {
         this[key] = value;
       }
     });

--- a/census/models/mixins.js
+++ b/census/models/mixins.js
@@ -6,8 +6,8 @@ var translated = function(locale) {
   var localized;
   if (this.translations && this.translations[locale]) {
     localized = this.translations[locale];
-    _.forEach(localized, function(value, key, list) {
-      if (this.hasOwnProperty(key)) {
+    _.forEach(localized, (value, key, list) => {
+      if (this.get(key) !== undefined) {
         this[key] = value;
       }
     });

--- a/census/models/utils.js
+++ b/census/models/utils.js
@@ -435,7 +435,7 @@ var getDataOptions = function(req) {
     year: req.params.year,
     cascade: req.params.cascade,
     scoredQuestionsOnly: true,
-    locale: req.params.locale,
+    locale: req.locale,
     with: {Entry: true, Dataset: true, Place: true, Question: true}
   };
 

--- a/fixtures/dataset.js
+++ b/fixtures/dataset.js
@@ -43,11 +43,12 @@ var objects = [
     data: {
       id: 'dataset21',
       site: 'site2',
-      name: 'Dataset 21',
+      name: 'English Dataset 21',
       description: 'Description of Dataset 21',
       order: 0,
       qsurl: 'http://example.com/googlespreadsheet',
-      questionsetid: 'questionset-hash'
+      questionsetid: 'questionset-hash',
+      translations: {es: {name: 'Spanish Dataset 21'}}
     }
   },
   {

--- a/tests/localization.js
+++ b/tests/localization.js
@@ -1,8 +1,7 @@
 'use strict';
 
-var _ = require('lodash');
-var assert = require('chai').assert;
-var testUtils = require('./utils');
+const assert = require('chai').assert;
+const testUtils = require('./utils');
 
 describe('Localization', function() {
   before(testUtils.startApplication);
@@ -42,21 +41,21 @@ describe('Localization', function() {
     browser.visit('/', function() {
       assert.ok(browser.success);
       var item = browser.query('.lang-picker span');
-      assert(!!item, 'There should be current language indicator');
+      assert(item, 'There should be current language indicator');
       var prevLanguage = item.textContent;
 
       item = browser.query('.lang-picker a');
-      assert(!!item, 'There should be language switcher');
+      assert(item, 'There should be language switcher');
       var requestedLanguage = item.textContent;
 
       browser.visit(item.getAttribute('href'), function() {
         assert.ok(browser.success);
         var item = browser.query('.lang-picker span');
-        assert(!!item, 'There should be current language indicator');
+        assert(item, 'There should be current language indicator');
         var newLanguage = item.textContent;
-        assert(prevLanguage != newLanguage,
+        assert(prevLanguage !== newLanguage,
           'New language should be different from previous');
-        assert(requestedLanguage == newLanguage,
+        assert(requestedLanguage === newLanguage,
           'New language should be the one that we requested');
         done();
       });

--- a/tests/localization.js
+++ b/tests/localization.js
@@ -47,11 +47,15 @@ describe('Localization', function() {
       item = browser.query('.lang-picker a');
       assert(item, 'There should be language switcher');
       var requestedLanguage = item.textContent;
+      browser.assert.text('.lang-picker span', 'EN');
+      assert.include(browser.html(), 'English Dataset 21');
 
       browser.visit(item.getAttribute('href'), function() {
         assert.ok(browser.success);
         var item = browser.query('.lang-picker span');
         assert(item, 'There should be current language indicator');
+        browser.assert.text('.lang-picker span', 'ES');
+        assert.include(browser.html(), 'Spanish Dataset 21');
         var newLanguage = item.textContent;
         assert(prevLanguage !== newLanguage,
           'New language should be different from previous');


### PR DESCRIPTION
This PR contains a number of fixes to allow translated Dataset fields in the CMS (using the `fieldname@LC` convention) to be loaded and used. 

Partly address #844.