### PR TITLE
Move 404 and 500 templates to /views dir

### DIFF
--- a/census/views/404.html
+++ b/census/views/404.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
 
-
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-<h1>{{ title }}</h1>
-<p>
-  {{ message }}
-</p>
+<div class="container">
+    <h1>{{ title }}</h1>
+    <p>
+      {{ message }}
+    </p>
+</div>
 {% endblock %}

--- a/census/views/500.html
+++ b/census/views/500.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
 
-
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-<h1>{{ title }}</h1>
-<p>
-  {{ message }}
-</p>
+<div class="container">
+    <h1>{{ title }}</h1>
+    <p>
+      {{ message }}
+    </p>
+</div>
 {% endblock %}


### PR DESCRIPTION
As part of migrating templates from `/views_old/` to `/views/`, this PR moves the 404 and 500 templates. It also fixes the mark up to better align the content in page.

Fixes #857.