### PR TITLE
Translate Question columns during CMS loading

### DIFF
--- a/census/loaders/index.js
+++ b/census/loaders/index.js
@@ -88,6 +88,8 @@ let _createQuestionsForQuestionSet = function(questionsUrl,
       _.map(data, dataObj => {
         // Allow custom data mapping
         let createData = controllerUtils.questionMapper(dataObj, qset.site);
+        // Map translation data
+        createData = _translationMapper(createData);
         let isOpen = _.contains(openQuestions, createData.id);
         // All Questions belong to a site and questionset
         createData = _.extend(createData, {


### PR DESCRIPTION
Reuses the guts of the existing `translationMapper` to create the appropriate `translations` object from `fieldname@lc` style columns in the CMS.

Partly addresses #788 and #844.