### PR TITLE
Allow dataset.characteristics localization

### DIFF
--- a/census/controllers/utils.js
+++ b/census/controllers/utils.js
@@ -302,5 +302,6 @@ module.exports = {
   getReviewers: getReviewers,
   canReview: canReview,
   FIELD_SPLITTER: FIELD_SPLITTER,
-  ANONYMOUS_USER_ID: ANONYMOUS_USER_ID
+  ANONYMOUS_USER_ID: ANONYMOUS_USER_ID,
+  commonFieldArray: commonFieldArray
 };

--- a/census/loaders/index.js
+++ b/census/loaders/index.js
@@ -49,7 +49,7 @@ var loadConfig = function(siteId, models) {
   into translation: {<language>: {<name>: ..., <another name>: ..., ...}}.
 */
 let _translationMapper = function(mapped) {
-  return _.extend(mapped, {
+  mapped = _.extend(mapped, {
     translations: _.chain(mapped)
       .pairs()
       .reduce(function(reducedValue, pair) {
@@ -65,6 +65,24 @@ let _translationMapper = function(mapped) {
       }, {})
       .value()
   });
+  // Handle characteristics for each language key
+  const characteristicsPattern = /^characteristics:\d+$/i;
+  _.forEach(mapped.translations, (transObj, key) => {
+    // Make an array of characteristics from all 'characteristics:n' keys
+    let characteristics =
+      controllerUtils.commonFieldArray(transObj, characteristicsPattern);
+    // If the characteristics array has items, add it to the translations obj.
+    if (characteristics.length) {
+      mapped.translations[key] = _.extend(mapped.translations[key], {
+        characteristics: characteristics
+      });
+    }
+    // Clean up items with 'characteristics:n' keys from translations obj.
+    mapped.translations[key] = _.omit(mapped.translations[key], (v, k) => {
+      return characteristicsPattern.test(k);
+    });
+  });
+  return mapped;
 };
 
 let _createQuestionsForQuestionSet = function(questionsUrl,

--- a/census/loaders/index.js
+++ b/census/loaders/index.js
@@ -52,16 +52,16 @@ let _translationMapper = function(mapped) {
   return _.extend(mapped, {
     translations: _.chain(mapped)
       .pairs()
-      .reduce(function(R, P) {
+      .reduce(function(reducedValue, pair) {
         let fieldLang;
-        if (!(P[0].indexOf('@') + 1)) {
-          return R;
+        if (!(pair[0].indexOf('@') + 1)) {
+          return reducedValue;
         }
-        fieldLang = P[0].split('@');
+        fieldLang = pair[0].split('@');
         // Default empty dict
-        R[fieldLang[1]] = R[fieldLang[1]] || {};
-        R[fieldLang[1]][fieldLang[0]] = P[1];
-        return R;
+        reducedValue[fieldLang[1]] = reducedValue[fieldLang[1]] || {};
+        reducedValue[fieldLang[1]][fieldLang[0]] = pair[1];
+        return reducedValue;
       }, {})
       .value()
   });

--- a/docs/site-admins/index.md
+++ b/docs/site-admins/index.md
@@ -146,7 +146,7 @@ To translate the primary language:
 
 To add another, second language (partial support for multiple languages): 
 
- * Add a column Name@{LANG} and Description@{LANG} to the Datasets sheet, where {LANG} is your 2 digit iso code (UpdateEvery and Characteristics:n are not currently supported)
+ * Add a column Name@{LANG}, Description@{LANG}, and Characteristics:n@{LANG} (one for each Characteristic) to the Datasets sheet, where {LANG} is your 2 digit iso code (UpdateEvery is not currently supported)
  * Translate the original Name and Description into your secondary language and enter into the new columns you created
  * Reload Datasets from the site admin page: <http://{your-census-id}.survey.okfn.org/admin>
 

--- a/fixtures/registry.js
+++ b/fixtures/registry.js
@@ -8,7 +8,7 @@ var objects = [
       id: 'site1',
       settings: {
         adminemail: ['email1@example.com'],
-        configurl: 'https://docs.google.com/a/okfn.org/spreadsheet/ccc?key=1PoS2loqokUbwxMEFXb1Zoe3goLISGga9RumvNf-VxGo&usp=sharing#gid=0'
+        configurl: 'https://docs.google.com/spreadsheets/d/1zKHbPdR1lRTuxvNFR32L1pQRJMWmj8C5UoKvECLsqtk/edit#gid=0'
       }
     }
   },
@@ -18,7 +18,7 @@ var objects = [
       id: 'site2',
       settings: {
         adminemail: ['email2@example.com'],
-        configurl: 'https://docs.google.com/a/okfn.org/spreadsheet/ccc?key=1PoS2loqokUbwxMEFXb1Zoe3goLISGga9RumvNf-VxGo&usp=sharing#gid=0'
+        configurl: 'https://docs.google.com/spreadsheets/d/1zKHbPdR1lRTuxvNFR32L1pQRJMWmj8C5UoKvECLsqtk/edit#gid=0'
       }
     }
   }

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -182,6 +182,10 @@ describe('Admin page', function () {
           assert.isTrue(_.has(transportInstance, 'translations.es.name'));
           assert.equal(_.get(transportInstance, 'translations.es.name'),
                          '(Spanish) Real-Time Transit');
+          assert.deepEqual(_.get(transportInstance, 'translations.es.characteristics'), [
+            '(Spanish) My first characteristic',
+            '(Spanish) Characteristic the second',
+            '(Spanish) The third and last of the istics']);
         });
     });
   });

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -4,8 +4,7 @@ const _ = require('lodash');
 const assert = require('chai').assert;
 const censusConfig = require('../census/config');
 const siteID = 'site1';
-const REGISTRY_URL = 'https://docs.google.com/spreadsheets/d/1FK5dzeNeJl81oB76n' +
-  'WzhS1dAdnXDoZbbe_vTH4NlThM/edit#gid=0';
+const REGISTRY_URL = 'https://docs.google.com/spreadsheets/d/1z12rUj039pcdeldPy9eXFcw0YF18b4sIRx6EXbLy-9A/edit#gid=0';
 const testUtils = require('./utils');
 const userFixtures = require('../fixtures/user');
 const Promise = require('bluebird');

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -174,6 +174,16 @@ describe('Admin page', function () {
           assert.isTrue(transportInstance.qsurl.startsWith('https://docs.google.com/spreadsheets'));
         });
     });
+
+    it('populates dataset.translations with fieldname@lc columns', function() {
+      return this.app.get('models').Dataset.findById('transport-realtime',
+                                                     {where: {site: siteID}})
+        .then(transportInstance => {
+          assert.isTrue(_.has(transportInstance, 'translations.es.name'));
+          assert.equal(_.get(transportInstance, 'translations.es.name'),
+                         '(Spanish) Real-Time Transit');
+        });
+    });
   });
 
   describe('reload questionset button action', function() {

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -38,10 +38,6 @@ describe('Admin page', function () {
     }
   });
 
-  before(function() {
-    return;
-  });
-
   describe('admin page', function() {
     before(function () {
       return this.browser.visit('/admin');


### PR DESCRIPTION
Add support for localizing Dataset Characteristics columns in the CMS. Translations can be added for each Characteristics column in the form `Characteristics:n@{lang_code}`, e.g. `Characteristics:0@ES`. During data loading into the database these are aggregated into a single array at the dataset key `translations.{lang_code}.characteristics`.

Fixes #859.