### PR TITLE
Handle divide by zero error when returning openDataPercent

### DIFF
--- a/census/models/utils.js
+++ b/census/models/utils.js
@@ -111,7 +111,7 @@ var processStats = function(data, options) {
     }).length;
     data.stats.openDataPercent = parseInt(
       (data.stats.currentEntryOpenCount / data.stats.currentEntryCount) * 100,
-      10);
+      10) || 0;
   } else {
     data.stats.currentEntryCount = 0;
     data.stats.currentEntryOpenCount = 0;

--- a/census/models/utils.js
+++ b/census/models/utils.js
@@ -115,7 +115,7 @@ var processStats = function(data, options) {
   } else {
     data.stats.currentEntryCount = 0;
     data.stats.currentEntryOpenCount = 0;
-    data.stats.openDataPercentCount = 0;
+    data.stats.openDataPercent = 0;
   }
 
   if (Array.isArray(data.datasets)) {

--- a/fixtures/site.js
+++ b/fixtures/site.js
@@ -33,6 +33,17 @@ var objects = [
         locales: ['en', 'es', 'uk']
       }
     }
+  },
+  {
+    model: 'Site',
+    data: {
+      id: 'site3',
+      settings: {
+        places: 'https://docs.google.com/spreadsheets/d/1QvZFGyICiuZmRxVll6peXkND_6QmHl7IQ_BYCw5Sso4/edit#gid=1',
+        datasets: 'https://docs.google.com/spreadsheets/d/18mw_Ig9zvwb514VQsTGfrg0WMrcUngxBIRzWSxpguho/edit#gid=0',
+        questions: 'https://docs.google.com/spreadsheets/d/1nwmk8uJEK-4K6-5SdBgoLUlUos-BhfYRgjS74YkhDGc/edit#gid=3',
+      }
+    }
   }
 ];
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -20,7 +20,8 @@ describe('Open Data Census Tests', function() {
   it('counts all sites', function() {
     let query = models.Site.findAll();
     return query.then(results => {
-      assert.equal(results.length, 2);
+      // 3 sites loaded from fixtures
+      assert.equal(results.length, 3);
     });
   });
 

--- a/tests/loaders.js
+++ b/tests/loaders.js
@@ -299,7 +299,7 @@ describe('System Control page', function () {
         this.app.get('models').Site.count(),
         this.app.get('models').Site.findById(siteID),
         function(count, siteData) {
-          assert.equal(count, 2);
+          assert.equal(count, 3);
           assert.isNotNull(siteData);
           assert.notEqual(siteData.places, '');
           assert.notEqual(siteData.places, '');

--- a/tests/models.js
+++ b/tests/models.js
@@ -306,6 +306,7 @@ describe('Data access layer', function() {
       expect(data).to.have.property('datasets');
       expect(data).to.have.property('places');
       expect(data).to.have.property('questions');
+      expect(data).to.have.property('stats');
     });
   });
 

--- a/tests/models.js
+++ b/tests/models.js
@@ -281,6 +281,57 @@ describe('Place instance methods', function() {
   });
 });
 
+describe('Stats object', function() {
+  this.timeout(20000);
+
+  beforeEach(utils.setupFixtures);
+  afterEach(utils.dropFixtures);
+
+  before(function() {
+    this.dataOptions = {
+      models: models,
+      domain: 'site3',
+      dataset: null,
+      place: null,
+      year: null,
+      cascade: true,
+      scoredQuestionsOnly: true,
+      locale: null,
+      with: {Entry: true, Dataset: true, Place: true, Question: true}
+    };
+  });
+
+  it('has 0 openDataPercent for site with no entries', function() {
+    return modelUtils.getData(this.dataOptions)
+    .then(data => {
+      expect(data.stats).to.have.property('openDataPercent');
+      expect(data.stats.openDataPercent).to.equal(0);
+    });
+  });
+
+  it('has expected openDataPercent for site with entries', function() {
+    let dataOptions = _.assign(this.dataOptions, {domain: 'site1'});
+    return modelUtils.getData(dataOptions)
+    .then(data => {
+      expect(data.stats).to.have.property('openDataPercent');
+      expect(data.stats.openDataPercent).to.equal(25);
+    });
+  });
+
+  it('has 0 openDataPercent when entries are excluded', function() {
+    let dataOptions = _.assign(this.dataOptions,
+      {
+        domain: 'site1',
+        with: {Entry: false, Dataset: false, Place: false, Question: false}
+      });
+    return modelUtils.getData(dataOptions)
+    .then(data => {
+      expect(data.stats).to.have.property('openDataPercent');
+      expect(data.stats.openDataPercent).to.equal(0);
+    });
+  });
+});
+
 describe('Data access layer', function() {
   this.timeout(20000);
 


### PR DESCRIPTION
Fixes #840 where 'NaN' was rendered to templates when a site had no approved entries.